### PR TITLE
Suggestions for the Interface

### DIFF
--- a/amigo/__init__.py
+++ b/amigo/__init__.py
@@ -11,7 +11,11 @@ from .model import Model
 from .optimizer import *
 from .utils import tocsr, topetsc, BSplineInterpolant
 from .unary_operations import *
-from .interfaces import ExternalOpenMDAOComponent, ExplicitOpenMDAOPostOptComponent
+from .interfaces import (
+    ExternalOpenMDAOComponent,
+    ExplicitOpenMDAOPostOptComponent,
+    AmigoIndepVarComp,
+)
 
 
 def get_include():

--- a/amigo/interfaces.py
+++ b/amigo/interfaces.py
@@ -223,10 +223,10 @@ def ExplicitOpenMDAOPostOptComponent(**kwargs):
                     name: inputs[self.data_mapping[name]].copy() for name in self.data
                 }
 
-            # Compute derivatives only when needed
-            self.dfdx, self.of_map, self.wrt_map = (
-                self.opt.compute_post_opt_derivatives(of=self.output, wrt=self.data)
-            )
+                # Compute derivatives only when inputs change
+                self.dfdx, self.of_map, self.wrt_map = (
+                    self.opt.compute_post_opt_derivatives(of=self.output, wrt=self.data)
+                )
 
             for of in self.of_map:
                 open_of = self.out_mapping[of]

--- a/examples/cart/cart_pole.py
+++ b/examples/cart/cart_pole.py
@@ -413,6 +413,7 @@ model = create_cart_model()
 
 if args.build:
     import sys
+
     compile_args = []
     link_args = []
     define_macros = []

--- a/examples/cart/cart_pole.py
+++ b/examples/cart/cart_pole.py
@@ -412,12 +412,16 @@ args = parser.parse_args()
 model = create_cart_model()
 
 if args.build:
+    import sys
     compile_args = []
     link_args = []
     define_macros = []
     if args.use_openmp:
-        compile_args = ["-fopenmp"]
-        link_args = ["-fopenmp"]
+        if sys.platform == "win32":
+            compile_args = ["/openmp"]
+        else:
+            compile_args = ["-fopenmp"]
+            link_args = ["-fopenmp"]
         define_macros = [("AMIGO_USE_OPENMP", "1")]
 
     model.build_module(


### PR DESCRIPTION
1. Fixed Shape Mismatch for multi-instance Components. Noticed that when using get_meta() it only returned the shape for a single component instance, causing mismatches when multiple instances exist. Changed to use get_indices() instead to get the actual shape across all component instances.
2. Noticed that derivatives were being computed in compute() even during forward analysis and line search. I'm not sure if it's correct, but I think they should only be computed when OpenMDAO calls compute_partials().

3. I re-ran an example with a simple parabola and noticed that if I give a new value different than the Amigo data values, it uses the one specified within the IndepVarComp. It still does, but I just added an option so you don't have to specify the shape and value manually - there's now a function that automatically reads the Amigo metadata.

Also, for the compute_partials case, there's a scenario where different inputs can be used in the forward analysis than the ones actually needed in compute_partials. I tried to make it explicit to verify if the input set changed, so we can re-optimize and get accurate derivatives.