### PR TITLE
Interface

### DIFF
--- a/amigo/interfaces.py
+++ b/amigo/interfaces.py
@@ -236,16 +236,16 @@ def ExplicitOpenMDAOPostOptComponent(**kwargs):
                     # Use np.ix_ for proper 2D submatrix extraction
                     of_indices = self.of_map[of]
                     wrt_indices = self.wrt_map[wrt]
-                    
+
                     # Handle both scalar and array indices
                     if np.isscalar(of_indices):
                         of_indices = [of_indices]
                     if np.isscalar(wrt_indices):
                         wrt_indices = [wrt_indices]
-                    
+
                     # Extract submatrix and reshape if needed
                     subjac = self.dfdx[np.ix_(of_indices, wrt_indices)]
-                    
+
                     # Flatten if both dimensions are arrays (for proper shape)
                     if len(of_indices) > 1 or len(wrt_indices) > 1:
                         partials[open_of, open_wrt] = subjac.flatten()


### PR DESCRIPTION
When extracting subjacobians from the full Jacobian matrix, the code was using direct array indexing which NumPy interprets as element wise pairing. For example, with two 50-element arrays as indices, it extracted only 50 diagonal like elements instead of the full 50×50 submatrix (2500 elements). This caused OpenMDAO to fail with a reshape error. I tried using np.ix_() to properly extract 2D submatrices by creating a mesh grid of all row-column combinations. This ensures the correct shape for array valued inputs and outputs.
