### PR TITLE
Implemented automatic simplification of expressions

### DIFF
--- a/amigo/component.py
+++ b/amigo/component.py
@@ -35,140 +35,20 @@ def _get_shape_from_list(obj):
     return (length,) + sub_shape
 
 
-# def _generate_cpp_input_decl(
-#     inputs,
-#     offset=0,
-#     mode="eval",
-#     alt_names=None,
-#     template_name="T__",
-#     input_name="input__",
-#     grad_name="boutput__",
-#     prod_name="pinput__",
-#     hprod_name="houtput__",
-# ):
-#     lines = []
+def _generate_cpp_types(inputs, template_name="T__"):
+    lines = []
 
-#     for index, name in enumerate(inputs):
-#         node = inputs[name]
-#         shape = _normalize_shape(node.shape)
-#         var_name = name if alt_names is None else alt_names[name]
+    for name in inputs:
+        shape = _normalize_shape(inputs[name].node.shape)
+        if shape is None:
+            lines.append(f"{template_name}")
+        else:
+            if len(shape) == 1:
+                lines.append(f"A2D::Vec<{template_name}, {shape[0]}>")
+            elif len(shape) == 2:
+                lines.append(f"A2D::Mat<{template_name}, {shape[0]}, {shape[1]}>")
 
-#         if mode == "eval":
-#             decl = None
-#             if shape is None:
-#                 decl = f"{template_name}& {var_name}"
-#             else:
-#                 if len(shape) == 1:
-#                     decl = f"A2D::Vec<{template_name}, {shape[0]}>& {var_name}"
-#                 elif len(shape) == 2:
-#                     decl = (
-#                         f"A2D::Mat<{template_name}, {shape[0]}, {shape[1]}>& {var_name}"
-#                     )
-#             lines.append(f"{decl} = A2D::get<{index + offset}>({input_name})")
-#         elif mode == "rev":
-#             decl = None
-#             if shape is None:
-#                 decl = f"A2D::ADObj<{template_name}&> {var_name}"
-#             else:
-#                 if len(shape) == 1:
-#                     decl = (
-#                         f"A2D::ADObj<A2D::Vec<{template_name}, {shape[0]}>&> {var_name}"
-#                     )
-#                 elif len(shape) == 2:
-#                     decl = f"A2D::ADObj<A2D::Mat<{template_name}, {shape[0]}, {shape[1]}>&> {var_name}"
-#             lines.append(
-#                 f"{decl}(A2D::get<{index + offset}>({input_name}), A2D::get<{index + offset}>({grad_name}))"
-#             )
-#         elif mode == "hprod":
-#             decl = None
-#             if shape is None:
-#                 decl = f"A2D::A2DObj<{template_name}&> {var_name}"
-#             else:
-#                 if len(shape) == 1:
-#                     decl = f"A2D::A2DObj<A2D::Vec<{template_name}, {shape[0]}>&> {var_name}"
-#                 elif len(shape) == 2:
-#                     decl = f"A2D::A2DObj<A2D::Mat<{template_name}, {shape[0]}, {shape[1]}>&> {var_name}"
-#             lines.append(
-#                 f"{decl}(A2D::get<{index + offset}>({input_name}), A2D::get<{index + offset}>({grad_name}), "
-#                 + f"A2D::get<{index + offset}>({prod_name}), A2D::get<{index + offset}>({hprod_name}))"
-#             )
-
-#     return lines
-
-
-# def _generate_cpp_var_decl(
-#     inputs, active=None, mode="eval", alt_names=None, template_name="T__"
-# ):
-#     lines = []
-
-#     for index, name in enumerate(inputs):
-#         node = inputs[name]
-#         shape = _normalize_shape(node.shape)
-#         var_name = name if alt_names is None else alt_names[name]
-
-#         passive = False
-#         if active is not None:
-#             if var_name in active and not active[var_name]:
-#                 passive = True
-
-#         if mode == "eval" or passive:
-#             decl = None
-#             if shape is None:
-#                 decl = f"{template_name} {var_name}"
-#             else:
-#                 if len(shape) == 1:
-#                     decl = f"A2D::Vec<{template_name}, {shape[0]}> {var_name}"
-#                 elif len(shape) == 2:
-#                     decl = (
-#                         f"A2D::Mat<{template_name}, {shape[0]}, {shape[1]}> {var_name}"
-#                     )
-#             lines.append(decl)
-#         elif mode == "rev":
-#             decl = None
-#             if shape is None:
-#                 decl = f"A2D::ADObj<{template_name}> {var_name}"
-#             else:
-#                 if len(shape) == 1:
-#                     decl = (
-#                         f"A2D::ADObj<A2D::Vec<{template_name}, {shape[0]}>> {var_name}"
-#                     )
-#                 elif len(shape) == 2:
-#                     decl = f"A2D::ADObj<A2D::Mat<{template_name}, {shape[0]}, {shape[1]}>> {var_name}"
-#             lines.append(decl)
-#         elif mode == "hprod":
-#             decl = None
-#             if shape is None:
-#                 decl = f"A2D::A2DObj<{template_name}> {var_name}"
-#             else:
-#                 if len(shape) == 1:
-#                     decl = (
-#                         f"A2D::A2DObj<A2D::Vec<{template_name}, {shape[0]}>> {var_name}"
-#                     )
-#                 elif len(shape) == 2:
-#                     decl = f"A2D::A2DObj<A2D::Mat<{template_name}, {shape[0]}, {shape[1]}>> {var_name}"
-#             lines.append(decl)
-
-#     return lines
-
-
-# def _generate_cpp_types(inputs, template_name="T__"):
-#     lines = []
-
-#     for index, name in enumerate(inputs):
-#         node = inputs[name]
-#         shape = _normalize_shape(node.shape)
-
-#         decl = None
-#         if shape is None:
-#             decl = f"{template_name}"
-#         else:
-#             if len(shape) == 1:
-#                 decl = f"A2D::Vec<{template_name}, {shape[0]}>"
-#             elif len(shape) == 2:
-#                 decl = f"A2D::Mat<{template_name}, {shape[0]}, {shape[1]}>"
-#         lines.append(decl)
-
-#     return lines
+    return lines
 
 
 class Meta:
@@ -280,34 +160,13 @@ class InputSet:
         return self.inputs[name]
 
     def get_shape(self, name):
-        return self.inputs[name].shape
+        return self.inputs[name].node.shape
 
     def get_meta(self, name):
         return self.meta[name]
 
     def generate_cpp_types(self, template_name="T__"):
         return _generate_cpp_types(self.inputs, template_name=template_name)
-
-    # def generate_cpp_input_decl(
-    #     self,
-    #     offset=0,
-    #     mode="eval",
-    #     template_name="T__",
-    #     input_name="input__",
-    #     grad_name="boutput__",
-    #     prod_name="pinput__",
-    #     hprod_name="houtput__",
-    # ):
-    #     return _generate_cpp_input_decl(
-    #         self.inputs,
-    #         offset=offset,
-    #         mode=mode,
-    #         template_name=template_name,
-    #         input_name=input_name,
-    #         grad_name=grad_name,
-    #         prod_name=prod_name,
-    #         hprod_name=hprod_name,
-    #     )
 
 
 class ConstantSet:
@@ -344,7 +203,7 @@ class ConstantSet:
     def generate_cpp_const_decl(self):
         lines = []
         for name in self.consts:
-            node = self.consts[name]
+            node = self.consts[name].node
             vtype = _cpp_type_map[node.type]
             lines.append(
                 f"inline static constexpr {vtype} {name} = static_cast<{vtype}>({node.value})"
@@ -387,12 +246,12 @@ class VarSet:
     def __setitem__(self, name, expr):
         if isinstance(expr, Expr):
             shape = None
-            self.vars[name] = self.VarExpr(name, shape=shape, active=expr.active)
+            self.vars[name] = self.VarExpr(name, shape=shape)
             self.vars[name].expr = expr
             expr.name = name
         else:
             shape = _get_shape_from_list(expr)
-            self.vars[name] = self.VarExpr(name, shape=shape, active=True)
+            self.vars[name] = self.VarExpr(name, shape=shape)
 
             # Check whether we should reset the active flag
             active = False
@@ -419,82 +278,6 @@ class VarSet:
     def generate_cpp_types(self, template_name="T__"):
         return _generate_cpp_types(self.vars, template_name=template_name)
 
-    # def generate_cpp_decl(self, mode="eval", template_name="T__"):
-    #     active = {}
-    #     for name in self.vars:
-    #         active[name] = self.vars[name].active
-
-    #     return _generate_cpp_var_decl(
-    #         self.vars, active, mode=mode, template_name=template_name
-    #     )
-
-    # def generate_passive_cpp(self):
-    #     lines = []
-    #     for name in self.vars:
-    #         if not self.vars[name].active:
-    #             shape = _normalize_shape(self.vars[name].shape)
-    #             if shape is None:
-    #                 rhs = self.vars[name].expr.generate_cpp(use_vars=False)
-    #                 lines.append(f"{name} = {rhs}")
-    #             elif len(shape) == 1:
-    #                 for i in range(shape[0]):
-    #                     rhs = self.vars[name].expr[i].generate_cpp(use_vars=False)
-    #                     lines.append(f"{name}[{i}] = {rhs}")
-    #             elif len(shape) == 2:
-    #                 for j in range(shape[1]):
-    #                     for i in range(shape[0]):
-    #                         rhs = (
-    #                             self.vars[name].expr[i][j].generate_cpp(use_vars=False)
-    #                         )
-    #                         lines.append(f"{name}({i},{j}) = {rhs}")
-
-    #     return lines
-
-    # def generate_active_cpp(self, mode="eval"):
-    #     lines = []
-
-    #     if mode == "eval":
-    #         for name in self.vars:
-    #             if self.vars[name].active:
-    #                 shape = _normalize_shape(self.vars[name].shape)
-    #                 if shape is None:
-    #                     rhs = self.vars[name].expr.generate_cpp(use_vars=False)
-    #                     lines.append(f"{name} = {rhs}")
-    #                 elif len(shape) == 1:
-    #                     for i in range(shape[0]):
-    #                         rhs = self.vars[name].expr[i].generate_cpp(use_vars=False)
-    #                         lines.append(f"{name}[{i}] = {rhs}")
-    #                 elif len(shape) == 2:
-    #                     for j in range(shape[1]):
-    #                         for i in range(shape[0]):
-    #                             rhs = (
-    #                                 self.vars[name]
-    #                                 .expr[i][j]
-    #                                 .generate_cpp(use_vars=False)
-    #                             )
-    #                             lines.append(f"{name}({i},{j}) = {rhs}")
-    #     else:
-    #         for name in self.vars:
-    #             if self.vars[name].active:
-    #                 shape = _normalize_shape(self.vars[name].shape)
-    #                 if shape is None:
-    #                     rhs = self.vars[name].expr.generate_cpp(use_vars=False)
-    #                     lines.append(f"A2D::Eval({rhs}, {name})")
-    #                 elif len(shape) == 1:
-    #                     for i in range(shape[0]):
-    #                         rhs = self.vars[name].expr[i].generate_cpp(use_vars=False)
-    #                         lines.append(f"A2D::Eval({rhs}, {name}[{i}])")
-    #                 elif len(shape) == 2:
-    #                     for j in range(shape[1]):
-    #                         for i in range(shape[0]):
-    #                             rhs = (
-    #                                 self.vars[name]
-    #                                 .expr[i][j]
-    #                                 .generate_cpp(use_vars=False)
-    #                             )
-    #                             lines.append(f"A2D::Eval({rhs}, {name}({i},{j}))")
-    #     return lines
-
 
 class DataSet:
     def __init__(self):
@@ -517,14 +300,8 @@ class DataSet:
     def generate_cpp_types(self, template_name="T__"):
         return _generate_cpp_types(self.data, template_name=template_name)
 
-    # def generate_cpp_input_decl(self, template_name="T__", data_name="data___"):
-    #     lines = _generate_cpp_input_decl(
-    #         self.data, mode="eval", template_name=template_name, input_name=data_name
-    #     )
-    #     return lines
-
     def get_shape(self, name):
-        return self.data[name].shape
+        return self.data[name].node.shape
 
     def get_meta(self, name):
         return self.meta[name]
@@ -550,10 +327,9 @@ class ConstraintSet:
                         for _ in range(self.shape[0])
                     ]
 
-    def __init__(self, lagrangian_name="lagrangian__"):
+    def __init__(self):
         self.cons = {}
         self.meta = {}
-        self.lagrangian_name = lagrangian_name
 
     def add(self, name, shape=None, type=float, **kwargs):
         self.cons[name] = self.ConstrExpr(name, shape=shape, type=type)
@@ -569,10 +345,10 @@ class ConstraintSet:
         return len(self.cons)
 
     def __iter__(self):
-        return iter(self.cons)
+        return iter(self.cons.keys())
 
     def __getitem__(self, name):
-        return self.cons[name]
+        return self.cons[name].expr
 
     def __setitem__(self, name, expr):
         if name not in self.cons:
@@ -605,132 +381,25 @@ class ConstraintSet:
     def evaluate(self, name, env):
         return self.cons[name].node.evaluate(env)
 
-    def _get_multiplier_names(self):
-        mult_names = {}
-        for name in self:
-            mult_names[name] = "lam_" + name + "__"
-
-        return mult_names
+    def get_multiplier_name(self, name):
+        if name in self.cons:
+            return f"lam_{name}__"
+        else:
+            raise KeyError(f"{name} not in declared constraints")
 
     def generate_cpp_types(self, template_name="T__"):
-        return _generate_cpp_types(self.cons, template_name=template_name)
+        lines = []
+        for name in self.cons:
+            shape = _normalize_shape(self.cons[name].shape)
+            if shape is None:
+                lines.append(f"{template_name}")
+            else:
+                if len(shape) == 1:
+                    lines.append(f"A2D::Vec<{template_name}, {shape[0]}>")
+                elif len(shape) == 2:
+                    lines.append(f"A2D::Mat<{template_name}, {shape[0]}, {shape[1]}>")
 
-    # def generate_cpp_input_decl(
-    #     self,
-    #     offset=0,
-    #     mode="eval",
-    #     template_name="T__",
-    #     input_name="input__",
-    #     grad_name="boutput__",
-    #     prod_name="pinput__",
-    #     hprod_name="houtput__",
-    # ):
-    #     mult_names = self._get_multiplier_names()
-    #     lines = _generate_cpp_input_decl(
-    #         self.cons,
-    #         alt_names=mult_names,
-    #         offset=offset,
-    #         mode=mode,
-    #         template_name=template_name,
-    #         input_name=input_name,
-    #         grad_name=grad_name,
-    #         prod_name=prod_name,
-    #         hprod_name=hprod_name,
-    #     )
-    #     return lines
-
-    # def generate_cpp_decl(self, mode="eval", template_name="T__"):
-    #     lines = _generate_cpp_var_decl(
-    #         self.cons, mode=mode, template_name=template_name
-    #     )
-    #     if mode == "eval":
-    #         lines.append(f"{template_name} {self.lagrangian_name}")
-    #     elif mode == "rev":
-    #         lines.append(f"A2D::ADObj<{template_name}> {self.lagrangian_name}")
-    #     else:
-    #         lines.append(f"A2D::A2DObj<{template_name}> {self.lagrangian_name}")
-    #     return lines
-
-    # def _lagrangian_evaluation(self, res_names, obj_expr=None):
-    #     expr_list = []
-
-    #     mult_names = self._get_multiplier_names()
-    #     for item in self.cons:
-    #         shape = self.cons[item].shape
-    #         name = self.cons[item].name
-
-    #         if shape is None:
-    #             res_name = res_names[name]
-    #             expr_list.append(f"({res_name}) * {mult_names[name]}")
-    #         elif len(shape) == 1:
-    #             for i in range(shape[0]):
-    #                 res_name = res_names[name][i]
-    #                 expr_list.append(f"({res_name}) * {mult_names[name]}[{i}]")
-    #         elif len(shape) == 2:
-    #             for i in range(shape[0]):
-    #                 for j in range(shape[1]):
-    #                     res_name = res_names[name][i][j]
-    #                     expr_list.append(f"({res_name}) * {mult_names[name]}({i}, {j})")
-
-    #     if obj_expr is None:
-    #         expr = ""
-    #     else:
-    #         expr = f"alpha__ * ({obj_expr})"
-
-    #     if len(expr_list) > 0:
-    #         if obj_expr is None:
-    #             expr = expr_list[0]
-    #         else:
-    #             expr += " + " + expr_list[0]
-    #         for i in range(1, len(expr_list)):
-    #             expr += " + " + expr_list[i]
-
-    #     return expr
-
-    # def generate_cpp(self, mode="eval", obj_expr=None):
-    #     lines = []
-
-    #     if mode == "eval":
-    #         make_line = lambda name, rhs: f"{name} = {rhs}"
-    #     else:
-    #         make_line = lambda name, rhs: f"A2D::Eval({rhs}, {name})"
-
-    #     res_names = {}
-    #     for item in self.cons:
-    #         shape = self.cons[item].shape
-    #         name = self.cons[item].name
-    #         if shape is None:
-    #             rhs = self.cons[item].expr.generate_cpp()
-    #             if self.cons[name].expr.active:
-    #                 res_names[name] = name
-    #                 lines.append(make_line(name, rhs))
-    #             else:
-    #                 res_names[name] = rhs
-    #         elif len(shape) == 1:
-    #             res_names[name] = []
-    #             for i in range(shape[0]):
-    #                 rhs = self.cons[item].expr[i].generate_cpp()
-    #                 if self.cons[name].expr[i].active:
-    #                     res_names[name].append(f"{name}[{i}]")
-    #                     lines.append(make_line(f"{name}[{i}]", rhs))
-    #                 else:
-    #                     res_names[name].append(rhs)
-    #         elif len(shape) == 2:
-    #             res_names[name] = []
-    #             for i in range(shape[0]):
-    #                 res_names[name][i].append([])
-    #                 for j in range(shape[1]):
-    #                     rhs = self.cons[item].expr[i][j].generate_cpp()
-    #                     if self.cons[name].expr[i][j].active:
-    #                         res_names[name][i].append(f"{name}({i}, {j})")
-    #                         lines.append(make_line(f"{name}({i}, {j}", rhs))
-    #                     else:
-    #                         res_names[name].append(rhs)
-
-    #     rhs = self._lagrangian_evaluation(res_names, obj_expr=obj_expr)
-    #     lines.append(make_line(f"{self.lagrangian_name}", rhs))
-
-    #     return lines
+        return lines
 
 
 class ObjectiveSet:
@@ -752,21 +421,23 @@ class ObjectiveSet:
     def __len__(self):
         return len(self.expr)
 
+    def __iter__(self):
+        return iter(self.expr)
+
     def __setitem__(self, name, expr):
         if name not in self.expr:
             raise KeyError(f"{name} not the declared objective")
         self.expr[name] = expr
         return
 
+    def __getitem__(self, name):
+        if name not in self.expr:
+            raise KeyError(f"{name} not the declared objective")
+        return self.expr[name]
+
     def clear(self):
         for name in self.expr:
             self.expr[name] = None
-
-    def generate_cpp(self):
-        for name in self.expr:
-            rhs = self.expr[name].generate_cpp()
-            return rhs
-        return None
 
     def get_meta(self, name):
         return self.meta[name]
@@ -806,6 +477,11 @@ class OutputSet:
         self.outputs[name].expr = expr
         return
 
+    def __getitem__(self, name):
+        if name not in self.outputs:
+            raise KeyError(f"{name} not the declared outputs")
+        return self.outputs[name].expr
+
     def get_shape(self, name):
         return self.outputs[name].shape
 
@@ -814,25 +490,21 @@ class OutputSet:
             self.outputs[name].expr = None
 
     def generate_cpp_types(self, template_name="T__"):
-        return _generate_cpp_types(self.outputs, template_name=template_name)
-
-    # def generate_cpp_input_decl(
-    #     self, offset=0, template_name="R__", output_name="output__"
-    # ):
-    #     return _generate_cpp_input_decl(
-    #         self.outputs,
-    #         offset=offset,
-    #         mode="eval",
-    #         template_name=template_name,
-    #         input_name=output_name,
-    #     )
-
-    def generate_cpp(self):
         lines = []
         for name in self.outputs:
-            rhs = self.outputs[name].expr.generate_cpp()
-            lines.append(f"{name} = {rhs}")
+            shape = _normalize_shape(self.outputs[name].shape)
+            if shape is None:
+                lines.append(f"{template_name}")
+            else:
+                if len(shape) == 1:
+                    lines.append(f"A2D::Vec<{template_name}, {shape[0]}>")
+                elif len(shape) == 2:
+                    lines.append(f"A2D::Mat<{template_name}, {shape[0]}, {shape[1]}>")
+
         return lines
+
+    def get_var(self, name):
+        return self.outputs[name].var
 
     def get_meta(self, name):
         return self.meta[name]
@@ -1018,16 +690,51 @@ class Component:
             out_shapes[name] = shape
         return out_shapes
 
-    def _compute_lagrangian(self):    
+    def _initialize_multipliers(self):
+        for name in self.constraints:
+            mult_name = self.constraints.get_multiplier_name(name)
+            if mult_name not in self.inputs:
+                shape = self.constraints.get_shape(name)
+                self.inputs.add(mult_name, shape=shape)
+
+        return
+
+    def _compute_lagrangian(self):
         # Compute the Lagrangian
         lhs = Expr(VarNode("lagrangian__"))
+        alpha = Expr(VarNode("alpha__", active=False))
         rhs = None
 
+        for name in self.objective:
+            rhs = alpha * self.objective[name]
+
         for name in self.constraints:
-            name = f"lam_{name}__"
+            mult_name = self.constraints.get_multiplier_name(name)
+            con = self.constraints[name]
+            lam = self.inputs[mult_name]
+
             shape = self.constraints.get_shape(name)
 
-            # term = 
+            if shape is None:
+                if rhs is None:
+                    rhs = con * lam
+                else:
+                    rhs = rhs + con * lam
+            elif len(shape) == 1:
+                if rhs is None:
+                    rhs = con[0] * lam[0]
+                else:
+                    rhs = rhs + con[0] * lam[0]
+                for i in range(1, shape[0]):
+                    rhs = rhs + con[i] * lam[i]
+            else:
+                for i in range(shape[0]):
+                    if rhs is None:
+                        rhs = con[i, 0] * lam[i, 0]
+                    else:
+                        rhs = rhs + con[i, 0] * lam[i, 0]
+                    for j in range(1, shape[1]):
+                        rhs = rhs + con[i, j] * lam[i, j]
 
         return rhs, lhs
 
@@ -1064,6 +771,91 @@ class Component:
 
         return using
 
+    def _generate_cpp_class_types(
+        self, class_name, template_name="T__", using_template="R__"
+    ):
+        cpp = ""
+
+        # Create the class structure
+        cpp += "\n" + f"template<typename {template_name}> \n"
+        cpp += f"class {class_name} " + "{\n"
+        cpp += " public:\n"
+
+        # Add the const declarations
+        const_decl = self.constants.generate_cpp_const_decl()
+        for line in const_decl:
+            cpp += "  " + line + ";\n"
+
+        # Add the input statement
+        if len(self.inputs) + len(self.constraints) > 0:
+            using = self._get_using_statement(
+                name="input", template_name=using_template
+            )
+            cpp += "  " + using + ";\n"
+            cpp += (
+                "  " + f"static constexpr int ncomp = Input<{template_name}>::ncomp;\n"
+            )
+        else:
+            cpp += (
+                "  "
+                + f"template <typename {using_template}> using Input = "
+                + f"typename A2D::VarTuple<{using_template}, {using_template}>;\n"
+            )
+            cpp += "  " + "static constexpr int ncomp = 0;\n"
+
+        # Add the data statement
+        if len(self.data) > 0:
+            using = self._get_using_statement(name="data", template_name=using_template)
+            cpp += "  " + using + ";\n"
+            cpp += (
+                "  " + f"static constexpr int ndata = Data<{template_name}>::ncomp;\n"
+            )
+        else:
+            cpp += (
+                "  "
+                + f"template <typename {using_template}> using Data = "
+                + f"typename A2D::VarTuple<{using_template}, {using_template}>;\n"
+            )
+            cpp += "  " + "static constexpr int ndata = 0;\n"
+
+        # Is compute actually empty
+        truth = "false"
+        if self.is_compute_empty():
+            truth = "true"
+        cpp += "  " + f"static constexpr bool is_compute_empty = {truth};\n"
+
+        # Is this a continuation component or not
+        truth = "false"
+        if self.is_continuation_component():
+            truth = "true"
+        cpp += "  " + f"static constexpr bool is_continuation_component = {truth};\n"
+
+        # Is compute_output actually empty?
+        truth = "false"
+        if self.is_output_empty():
+            truth = "true"
+        cpp += "  " + f"static constexpr bool is_output_empty = {truth};\n"
+
+        # Add the output statement
+        if len(self.outputs) > 0:
+            using = self._get_using_statement(
+                name="output", template_name=using_template
+            )
+            cpp += "  " + using + ";\n"
+            cpp += (
+                "  "
+                + f"static constexpr int noutputs = Output<{template_name}>::ncomp;\n"
+            )
+        else:
+            cpp += (
+                "  "
+                + f"template<typename {using_template}> "
+                + f"using Output = typename A2D::VarTuple<{using_template}, {using_template}>;\n"
+            )
+            cpp += "  " + "static constexpr int noutputs = 0;\n"
+
+        return cpp
+
     def generate_cpp(
         self,
         template_name="T__",
@@ -1082,6 +874,14 @@ class Component:
 
         cpp = ""
 
+        # Initialize the multipliers that are added to the inputs
+        self._initialize_multipliers()
+
+        # Make lists of the constants
+        consts = [self.constants[name] for name in self.constants]
+        data = [self.data[name] for name in self.data]
+        inputs = [self.inputs[name] for name in self.inputs]
+
         for index, args in enumerate(self.args):
             # Re-initialize any variables or other arguments
             self.clear()
@@ -1097,81 +897,37 @@ class Component:
             else:
                 class_name = self.name + str(index) + "__"
 
-            # Create the class structure
-            cpp += "\n" + f"template<typename {template_name}> \n"
-            cpp += f"class {class_name} " + "{\n"
-            cpp += " public:\n"
-
-            # Add the const declarations
-            const_decl = self.constants.generate_cpp_const_decl()
-            for line in const_decl:
-                cpp += "  " + line + ";\n"
-
-            # Add the input statement
-            if len(self.inputs) + len(self.constraints) > 0:
-                using = self._get_using_statement(
-                    name="input", template_name=using_template
-                )
-                cpp += "  " + using + ";\n"
-                cpp += (
-                    "  "
-                    + f"static constexpr int ncomp = Input<{template_name}>::ncomp;\n"
-                )
-            else:
-                cpp += (
-                    "  "
-                    + f"template <typename {using_template}> using Input = "
-                    + f"typename A2D::VarTuple<{using_template}, {using_template}>;\n"
-                )
-                cpp += "  " + "static constexpr int ncomp = 0;\n"
-
-            # Add the data statement
-            if len(self.data) > 0:
-                using = self._get_using_statement(
-                    name="data", template_name=using_template
-                )
-                cpp += "  " + using + ";\n"
-                cpp += (
-                    "  "
-                    + f"static constexpr int ndata = Data<{template_name}>::ncomp;\n"
-                )
-            else:
-                cpp += (
-                    "  "
-                    + f"template <typename {using_template}> using Data = "
-                    + f"typename A2D::VarTuple<{using_template}, {using_template}>;\n"
-                )
-                cpp += "  " + "static constexpr int ndata = 0;\n"
-
-            # Is compute actually empty
-            truth = "false"
-            if self.is_compute_empty():
-                truth = "true"
-            cpp += "  " + f"static constexpr bool is_compute_empty = {truth};\n"
-
-            # Is this a continuation component or not
-            truth = "false"
-            if self.is_continuation_component():
-                truth = "true"
-            cpp += (
-                "  " + f"static constexpr bool is_continuation_component = {truth};\n"
+            cpp += self._generate_cpp_class_types(
+                class_name, template_name=template_name, using_template=using_template
             )
 
-            rhs, lhs = self._compute_lagrangian()                        
+            # Get the expression for the Lagrangian
+            rhs, lhs = self._compute_lagrangian()
 
-            builder = ExprBuilder(self.constants, self.data, self.inputs, self.vars, rhs=rhs, lhs=lhs)
+            if rhs is None:
+                rhs = []
+            if lhs is None:
+                lhs = []
 
-            for mode in ["eval", "rev", "hprod"]:
-                # cpp += self._generate_compute_cpp(
-                #     mode,
-                #     template_name=using_template,
-                #     data_name=data_name,
-                #     input_name=input_name,
-                #     grad_name=grad_name,
-                #     prod_name=prod_name,
-                #     hprod_name=hprod_name,
-                #     stack_name=stack_name,
-                # )
+            # Get any variables that might have been set
+            vars = [self.vars[name] for name in self.vars]
+
+            # Create the expression builder
+            builder = ExprBuilder(consts, data, inputs, vars, rhs=rhs, lhs=lhs)
+
+            for mode in ["eval", "grad", "hprod"]:
+                cpp += self._generate_compute_cpp(
+                    builder,
+                    lhs,
+                    mode,
+                    template_name=using_template,
+                    data_name=data_name,
+                    input_name=input_name,
+                    grad_name=grad_name,
+                    prod_name=prod_name,
+                    hprod_name=hprod_name,
+                    stack_name=stack_name,
+                )
 
             # Clear the variables for the compute_output function
             self.clear()
@@ -1182,31 +938,19 @@ class Component:
             else:
                 self.compute_output()
 
-            # Add the output statement
-            if len(self.outputs) > 0:
-                using = self._get_using_statement(
-                    name="output", template_name=using_template
-                )
-                cpp += "  " + using + ";\n"
-                cpp += (
-                    "  "
-                    + f"static constexpr int noutputs = Output<{template_name}>::ncomp;\n"
-                )
-            else:
-                cpp += (
-                    "  "
-                    + f"template<typename {using_template}> "
-                    + f"using Output = typename A2D::VarTuple<{using_template}, {using_template}>;\n"
-                )
-                cpp += "  " + "static constexpr int noutputs = 0;\n"
+            # Get any variables that might have been set
+            vars = [self.vars[name] for name in self.vars]
 
-            # Is compute_output actually empty
-            truth = "false"
-            if self.is_output_empty():
-                truth = "true"
-            cpp += "  " + f"static constexpr bool is_output_empty = {truth};\n"
+            outputs, lhs = [], []
+            for name in self.outputs:
+                outputs.append(self.outputs[name])
+                lhs.append(self.outputs.get_var(name))
+
+            # Create the expression builder
+            builder = ExprBuilder(consts, data, inputs, vars, rhs=outputs, lhs=lhs)
 
             cpp += self._generate_output_cpp(
+                builder,
                 template_name=using_template,
                 data_name=data_name,
                 input_name=input_name,
@@ -1219,6 +963,8 @@ class Component:
 
     def _generate_compute_cpp(
         self,
+        builder,
+        lhs,
         mode,
         template_name="T__",
         data_name="data__",
@@ -1240,7 +986,7 @@ class Component:
                 + f"Input<{template_name}>& {input_name}) "
                 + "{\n"
             )
-        elif mode == "rev":
+        elif mode == "grad":
             cpp += (
                 f"{pre} void gradient({template_name} alpha__, "
                 + f"Data<{template_name}>& {data_name}, "
@@ -1262,70 +1008,33 @@ class Component:
         is_empty = self.is_compute_empty()
 
         if not is_empty:
-            data_decl = self.data.generate_cpp_input_decl(
-                template_name=template_name, data_name=data_name
-            )
-            for line in data_decl:
-                cpp += "    " + line + ";\n"
-
-            in_decl = self.inputs.generate_cpp_input_decl(
+            decl, passive, active = builder.get_cpp_lines(
                 mode=mode,
                 template_name=template_name,
+                data_name=data_name,
                 input_name=input_name,
                 grad_name=grad_name,
                 prod_name=prod_name,
                 hprod_name=hprod_name,
             )
-            for line in in_decl:
-                cpp += "    " + line + ";\n"
-
-            offset = self.inputs.get_num_inputs()
-            con_decl = self.constraints.generate_cpp_input_decl(
-                mode=mode,
-                offset=offset,
-                template_name=template_name,
-                input_name=input_name,
-                grad_name=grad_name,
-                prod_name=prod_name,
-                hprod_name=hprod_name,
-            )
-            for line in con_decl:
-                cpp += "    " + line + ";\n"
-
-            var_decl = self.vars.generate_cpp_decl(
-                mode=mode, template_name=template_name
-            )
-            for line in var_decl:
-                cpp += "    " + line + ";\n"
-
-            con_decl = self.constraints.generate_cpp_decl(
-                mode=mode, template_name=template_name
-            )
-            for line in con_decl:
-                cpp += "    " + line + ";\n"
-
-            lines = self.vars.generate_passive_cpp()
-            for line in lines:
-                cpp += "    " + f"{line};\n"
-
-            obj_expr = self.objective.generate_cpp()
-            body = self.vars.generate_active_cpp(mode=mode)
-            body.extend(self.constraints.generate_cpp(mode=mode, obj_expr=obj_expr))
 
             if mode == "eval":
-                for line in body:
+                for line in decl + passive + active:
                     cpp += "    " + line + ";\n"
-                cpp += "    " + f"return {self.constraints.lagrangian_name};\n"
+                cpp += "    " + f"return {lhs.to_cpp()};\n"
             else:
+                for line in decl + passive:
+                    cpp += "    " + line + ";\n"
+
                 cpp += "    " + f"auto {stack_name} = A2D::MakeStack(\n"
-                for index, line in enumerate(body):
+                for index, line in enumerate(active):
                     cpp += "      " + line
-                    if index == len(body) - 1:
+                    if index == len(active) - 1:
                         cpp += ");\n"
                     else:
                         cpp += ",\n"
 
-                cpp += "    " + f"{self.constraints.lagrangian_name}.bvalue() = 1.0;\n"
+                cpp += "    " + f"{lhs.to_cpp()}.bvalue() = 1.0;\n"
                 cpp += "    " + f"{stack_name}.reverse();\n"
                 if mode == "hprod":
                     cpp += "    " + f"{stack_name}.hforward();\n"
@@ -1340,6 +1049,7 @@ class Component:
 
     def _generate_output_cpp(
         self,
+        builder,
         template_name="R__",
         data_name="data__",
         input_name="input__",
@@ -1354,53 +1064,12 @@ class Component:
             + f"Output<{template_name}>& {output_name})"
             + " {\n"
         )
-        data_decl = self.data.generate_cpp_input_decl(
-            template_name=template_name, data_name=data_name
-        )
-        for line in data_decl:
-            cpp += "    " + line + ";\n"
 
-        in_decl = self.inputs.generate_cpp_input_decl(
-            mode="eval",
-            template_name=template_name,
-            input_name=input_name,
-        )
-        for line in in_decl:
-            cpp += "    " + line + ";\n"
+        if not self.is_output_empty():
+            decl, passive, active = builder.get_cpp_lines(mode="eval")
 
-        offset = self.inputs.get_num_inputs()
-        con_decl = self.constraints.generate_cpp_input_decl(
-            mode="eval",
-            offset=offset,
-            template_name=template_name,
-            input_name=input_name,
-        )
-        for line in con_decl:
-            cpp += "    " + line + ";\n"
-
-        offset += self.constraints.get_num_constraints()
-        out_decl = self.outputs.generate_cpp_input_decl(
-            template_name=template_name,
-            output_name=output_name,
-        )
-        for line in out_decl:
-            cpp += "    " + line + ";\n"
-
-        var_decl = self.vars.generate_cpp_decl(mode="eval", template_name=template_name)
-        for line in var_decl:
-            cpp += "    " + line + ";\n"
-
-        body = self.vars.generate_passive_cpp()
-        for line in body:
-            cpp += "    " + line + ";\n"
-
-        body = self.vars.generate_active_cpp(mode="eval")
-        for line in body:
-            cpp += "    " + line + ";\n"
-
-        lines = self.outputs.generate_cpp()
-        for line in lines:
-            cpp += "    " + line + ";\n"
+            for line in decl + passive + active:
+                cpp += "    " + line + ";\n"
 
         cpp += "  }\n"
 

--- a/amigo/expressions.py
+++ b/amigo/expressions.py
@@ -1,12 +1,26 @@
-import math
+def _normalize_shape(shape):
+    if shape is None:
+        return None
+    if isinstance(shape, int):
+        shape = (shape,)
+    elif not isinstance(shape, tuple):
+        raise TypeError("Expecting None, int or tuple")
+    if not (len(shape) == 1 or len(shape) == 2):
+        raise ValueError("Amigo only accepts shapes with at most two dimensions")
+    return shape
 
 
 class ExprNode:
-    def __init__(self):
-        self.name = None
-        self.active = False
+    def to_key(self):
+        raise NotImplementedError
 
-    def generate_cpp(self, index=None):
+    def to_cpp(self):
+        raise NotImplementedError
+
+    def is_active(self):
+        raise NotImplementedError
+
+    def compute_cost(self):
         raise NotImplementedError
 
 
@@ -16,72 +30,139 @@ class ConstNode(ExprNode):
         self.name = name
         self.value = value
         self.type = type
-        self.active = False
 
-    def generate_cpp(self, index=None):
+    def to_key(self):
+        return ("const", self.name, self.value, self.type)
+
+    def to_cpp(self):
         if self.name is not None:
             return self.name
         return str(self.value)
+
+    def is_active(self):
+        return False
+
+    def compute_cost(self):
+        return 0
 
 
 class VarNode(ExprNode):
     def __init__(self, name, shape=None, type=float, active=True):
         super().__init__()
         self.name = name
-        self.shape = shape
+        self.shape = _normalize_shape(shape)
         self.type = type
         self.active = active
 
-    def generate_cpp(self, index=None):
-        if index is None:
-            return self.name
-        elif isinstance(index, tuple):
-            # For 2D index like A[i][j]
-            i_str = index[0].generate_cpp()
-            j_str = index[1].generate_cpp()
-            return f"{self.name}({i_str}, {j_str})"
-        else:
-            return f"{self.name}[{index.generate_cpp()}]"
+    def to_key(self):
+        return ("var", self.name, self.shape, self.type, self.active)
+
+    def to_cpp(self):
+        return self.name
+
+    def is_active(self):
+        return self.active
+
+    def compute_cost(self):
+        return 0
 
 
 class IndexNode(ExprNode):
-    def __init__(self, array_node, index_node):
+    def __init__(self, expr, index):
         super().__init__()
-        self.array_node = array_node
-        self.index_node = index_node  # can be ExprNode or tuple of ExprNodes
-        self.active = self.array_node.active
+        self.expr = expr
+        self.index = index
 
-    def generate_cpp(self, index=None):
-        arr = self.array_node.generate_cpp()
-        if isinstance(self.index_node, tuple):
-            idxs = tuple(i.generate_cpp(index) for i in self.index_node)
-            return f"{arr}({idxs[0]}, {idxs[1]})"
+    def to_key(self):
+        return ("index", self.expr.to_key(), self.index)
+
+    def to_cpp(self):
+        arr = self.expr.to_cpp()
+        if isinstance(self.index, tuple):
+            return f"{arr}({self.index[0]}, {self.index[1]})"
         else:
-            idx = self.index_node.generate_cpp(index)
-            return f"{arr}[{idx}]"
+            return f"{arr}[{self.index}]"
+
+    def is_active(self):
+        return self.expr.is_active()
+
+    def compute_cost(self):
+        return 0
 
 
-class OpNode(ExprNode):
+class PassiveNode(ExprNode):
+    def __init__(self, expr):
+        self.expr = expr
+
+    def to_key(self):
+        return ("passive", self.expr.to_key())
+
+    def to_cpp(self):
+        a = self.expr.to_cpp()
+        return f"A2D::get_data({a})"
+
+    def is_active(self):
+        return False
+
+    def compute_cost(self):
+        return 0
+
+
+class UnaryNode(ExprNode):
+    def __init__(self, op, expr):
+        super().__init__()
+        self.op = op
+        self.expr = expr
+
+    def to_key(self):
+        return ("unary", self.op, self.expr.to_key())
+
+    def to_cpp(self):
+        a = self.expr.to_cpp()
+        if self.op == "-":
+            return f"-({a})"
+        return f"A2D::{self.op}({a})"
+
+    def is_active(self):
+        return self.expr.is_active()
+
+    def compute_cost(self):
+        cost = self.expr.compute_cost()
+
+        trig = ["sin", "cos", "tan", "asin", "acos", "atan"]
+        exp = ["exp", "sinh", "cosh", "tanh", "asinh", "acosh", "atanh"]
+        log = ["log", "log10"]
+
+        if self.op == "-" or self.op == "fabs":
+            cost += 1
+        elif self.op == "sqrt":
+            cost += 20
+        elif self.op in trig:
+            cost += 100
+        elif self.op in exp:
+            cost += 100
+        elif self.op in log:
+            cost += 200
+
+        return cost
+
+
+class BinaryNode(ExprNode):
     def __init__(self, op, left, right):
         super().__init__()
         self.op = op
         self.left = left
         self.right = right
-        if self.left.active or self.right.active:
-            self.active = True
-        else:
-            self.active = False
 
-    def generate_cpp(self, index=None):
-        a = self.left.generate_cpp(index)
-        b = self.right.generate_cpp(index)
+    def to_key(self):
+        return ("binary", self.op, self.left.to_key(), self.right.to_key())
+
+    def to_cpp(self):
+        a = self.left.to_cpp()
+        b = self.right.to_cpp()
+
         if self.op == "**":
-            # Specialize pow for case with constant integer powers
-            rnode = self.right.node
-            if isinstance(rnode, ConstNode) and rnode.type == int and rnode.value > 0:
-                return " * ".join([f"({a})"] * rnode.value)
-            else:
-                return f"A2D::pow({a}, {b})"
+            return f"A2D::pow({a}, {b})"
         elif self.op == "atan2":
             return f"A2D::atan2({a}, {b})"
         elif self.op == "min2":
@@ -90,39 +171,29 @@ class OpNode(ExprNode):
             return f"A2D::max2({a}, {b})"
         return f"({a} {self.op} {b})"
 
+    def is_active(self):
+        return self.left.is_active() or self.right.is_active()
 
-class UnaryNode(ExprNode):
-    def __init__(self, func_name, func, operand):
-        super().__init__()
-        self.func_name = func_name
-        self.func = func
-        self.operand = operand
-        self.active = operand.active
+    def compute_cost(self):
+        cost = self.left.compute_cost() + self.right.compute_cost()
 
-    def generate_cpp(self, index=None):
-        a = self.operand.generate_cpp(index)
-        return f"A2D::{self.func_name}({a})"
+        if self.op == "**":
+            rnode = self.right.node
+            if isinstance(rnode, ConstNode) and rnode.type == int:
+                if rnode.value >= 0:
+                    cost += rnode.value
+                elif rnode.value < 0:
+                    cost += 10 + rnode.value
+            else:
+                cost += 100
+        elif self.op == "atan2":
+            cost += 100
+        elif self.op == "/":
+            cost += 10
+        else:
+            cost += 1
 
-
-class UnaryNegNode(ExprNode):
-    def __init__(self, operand):
-        super().__init__()
-        self.operand = operand
-        self.active = self.operand.active
-
-    def generate_cpp(self, index=None):
-        a = self.operand.generate_cpp(index)
-        return f"-({a})"
-
-
-class PassiveNode(ExprNode):
-    def __init__(self, expr):
-        self.active = False
-        self.expr = expr
-
-    def generate_cpp(self, index=None):
-        a = self.expr.generate_cpp(index)
-        return f"A2D::get_data({a})"
+        return cost
 
 
 def _to_expr(val):
@@ -141,49 +212,419 @@ class Expr:
     def __init__(self, node: ExprNode):
         self.name = None
         self.node = node
-        self.active = node.active
 
     def __neg__(self):
-        return Expr(UnaryNegNode(self.node))
+        return Expr(UnaryNode("-", self.node))
 
     def __add__(self, other):
-        return Expr(OpNode("+", self, _to_expr(other)))
+        return Expr(BinaryNode("+", self, _to_expr(other)))
 
     def __sub__(self, other):
-        return Expr(OpNode("-", self, _to_expr(other)))
+        return Expr(BinaryNode("-", self, _to_expr(other)))
 
     def __mul__(self, other):
-        return Expr(OpNode("*", self, _to_expr(other)))
+        return Expr(BinaryNode("*", self, _to_expr(other)))
 
     def __truediv__(self, other):
-        return Expr(OpNode("/", self, _to_expr(other)))
+        return Expr(BinaryNode("/", self, _to_expr(other)))
 
     def __pow__(self, other):
-        return Expr(OpNode("**", self, _to_expr(other)))
+        if isinstance(other, int):
+            if other == 0:
+                return Expr(ConstNode(value=1.0))
+            elif other > 0:
+                tmp = self
+                for i in range(other - 1):
+                    tmp = tmp * self
+                return tmp
+            elif other < 0:
+                tmp = self
+                for i in range(-other - 1):
+                    tmp = tmp * self
+                return 1.0 / tmp
+        return Expr(BinaryNode("**", self, _to_expr(other)))
 
     def __radd__(self, other):
-        return Expr(OpNode("+", _to_expr(other), self))
+        return Expr(BinaryNode("+", _to_expr(other), self))
 
     def __rsub__(self, other):
-        return Expr(OpNode("-", _to_expr(other), self))
+        return Expr(BinaryNode("-", _to_expr(other), self))
 
     def __rmul__(self, other):
-        return Expr(OpNode("*", _to_expr(other), self))
+        return Expr(BinaryNode("*", _to_expr(other), self))
 
     def __rtruediv__(self, other):
-        return Expr(OpNode("/", _to_expr(other), self))
+        return Expr(BinaryNode("/", _to_expr(other), self))
 
     def __rpow__(self, other):
-        return Expr(OpNode("**", _to_expr(other), self))
+        return Expr(BinaryNode("**", _to_expr(other), self))
 
     def __getitem__(self, idx):
-        if isinstance(idx, tuple):
-            idx_node = tuple(_to_expr(i) for i in idx)
-        else:
-            idx_node = _to_expr(idx)
-        return Expr(IndexNode(self.node, idx_node))
+        if isinstance(self.node, VarNode):
+            if isinstance(idx, tuple):
+                index = tuple(int(i) for i in idx)
+                if index[0] < 0 or index[0] >= self.node.shape[0]:
+                    raise ValueError(f"First index {index[0]} out of range")
+                if index[1] < 0 or index[1] >= self.node.shape[1]:
+                    raise ValueError(f"Second index {index[1]} out of range")
+            else:
+                index = int(idx)
+                if index < 0 or index >= self.node.shape[0]:
+                    raise ValueError(f"Index {index} out of range")
 
-    def generate_cpp(self, index=None, use_vars=True):
+            return Expr(IndexNode(self, index))
+        else:
+            raise TypeError("You can only index variables, not general expressions")
+
+    def to_key(self):
+        return self.node.to_key()
+
+    def to_cpp(self, use_vars=True):
         if use_vars and self.name is not None:
             return self.name
-        return self.node.generate_cpp(index=index)
+        return self.node.to_cpp()
+
+    def set_active_flag(self, flag):
+        if isinstance(self.node, VarNode):
+            self.node.active = flag
+        else:
+            raise ValueError("Cannot set active flag for node ", self.node)
+
+    def is_active(self):
+        return self.node.is_active()
+
+    def compute_cost(self):
+        return self.node.compute_cost()
+
+
+class ExprBuilder:
+    def __init__(self, consts=[], data=[], inputs=[], vars=[], rhs=[], lhs=[]):
+        self.consts = consts
+        self.data = data
+        self.inputs = inputs
+        self.vars = vars
+        if isinstance(rhs, list):
+            self.rhs = rhs
+        elif isinstance(rhs, Expr):
+            self.rhs = [rhs]
+        else:
+            raise TypeError("Unrecognized rhs type")
+        if isinstance(lhs, list):
+            self.lhs = lhs
+        elif isinstance(lhs, Expr):
+            self.lhs = [lhs]
+        else:
+            raise TypeError("Unrecognized lhs type")
+
+        # Convert from/to strings to/from type
+        self.type_to_str = {float: "float", int: "int"}
+        self.str_to_type = {"float": float, "int": int}
+
+        # Initialize the internal data
+        self.counter = 0
+        self.key_to_id = {}
+        self.nodes = {}
+
+        # Serialize the constants, data, inputs and vars
+        self.const_list = list(self._serialize_expr(c) for c in self.consts)
+        self.data_list = list(self._serialize_expr(d) for d in self.data)
+        self.input_list = list(self._serialize_expr(x) for x in self.inputs)
+        self.var_list = list(self._serialize_expr(v) for v in self.vars)
+
+        # Serialize the expressions
+        self.rhs_list = list(self._serialize_expr(e) for e in self.rhs)
+
+        self.counts = [0] * len(self.nodes)
+        self.node_exprs = [None] * len(self.nodes)
+        temp_var_exprs = {}
+
+        # Set the expressions for the nodes
+        for i, idx in enumerate(self.const_list):
+            self.node_exprs[idx] = self.consts[i]
+        for i, idx in enumerate(self.data_list):
+            self.node_exprs[idx] = self.data[i]
+        for i, idx in enumerate(self.input_list):
+            self.node_exprs[idx] = self.inputs[i]
+
+        make_temp_name = lambda idx: f"t{idx}__"
+
+        # Create the temporary variables specified by the user
+        self.temp_list = []
+        for i, idx in enumerate(self.var_list):
+            temp_var_exprs[idx] = self.vars[i]
+            self.temp_list.append(idx)
+            name = make_temp_name(idx)
+            self.node_exprs[idx] = Expr(VarNode(name, type=float))
+
+        # Count up the references to each node, locating temporaries
+        for i in range(len(self.nodes)):
+            node = self.nodes[i]
+            if node["type"] == "unary":
+                self.counts[node["expr"]] += 1
+            elif node["type"] == "binary":
+                self.counts[node["left"]] += 1
+                self.counts[node["right"]] += 1
+
+        # Add the temporaries to the list
+        for idx in range(len(self.counts)):
+            node = self.nodes[idx]
+            if node["type"] == "unary" or node["type"] == "binary":
+                if self.counts[idx] > 1:
+                    self.temp_list.append(idx)
+                    name = make_temp_name(idx)
+                    self.node_exprs[idx] = Expr(VarNode(name, type=float))
+
+        # Build the expressions
+        for idx in self.temp_list:
+            temp_var_exprs[idx] = self._build_expr(idx)
+
+        # Set it up so that the temp expressions are in order
+        self.temp_exprs = []
+        for idx in sorted(self.temp_list):
+            # Set whether the temporaries are active or not
+            self.node_exprs[idx].set_active_flag(temp_var_exprs[idx].is_active())
+            self.temp_exprs.append([self.node_exprs[idx], temp_var_exprs[idx]])
+
+        # Set the new expressions
+        self.new_rhs = []
+        for idx in self.rhs_list:
+            self.new_rhs.append(self._build_expr(idx))
+
+        return
+
+    def _serialize_expr(self, e: Expr):
+        key = e.to_key()
+        if key in self.key_to_id:
+            return self.key_to_id[key]
+
+        node = e.node
+        if isinstance(node, ConstNode):
+            info = {
+                "type": "const",
+                "name": node.name,
+                "value": node.value,
+                "vartype": self.type_to_str[node.type],
+            }
+        elif isinstance(node, VarNode):
+            info = {
+                "type": "var",
+                "name": node.name,
+                "shape": node.shape,
+                "vartype": self.type_to_str[node.type],
+                "active": node.active,
+            }
+        elif isinstance(node, IndexNode):
+            info = {
+                "type": "index",
+                "expr": self._serialize_expr(node.expr),
+                "index": node.index,
+            }
+        elif isinstance(node, PassiveNode):
+            info = {
+                "type": "passive",
+                "expr": self._serialize_expr(node.expr),
+            }
+        elif isinstance(node, UnaryNode):
+            info = {
+                "type": "unary",
+                "op": node.op,
+                "expr": self._serialize_expr(node.expr),
+            }
+        elif isinstance(node, BinaryNode):
+            info = {
+                "type": "binary",
+                "op": node.op,
+                "left": self._serialize_expr(node.left),
+                "right": self._serialize_expr(node.right),
+            }
+        else:
+            raise TypeError(type(node))
+
+        count = self.counter
+        self.key_to_id[key] = count
+        self.nodes[count] = info
+        self.counter += 1
+
+        return count
+
+    def serialize(self):
+        return {"version": 1, "nodes": self.nodes}
+
+    def _build_expr(self, idx):
+        node = self.nodes[idx]
+        if node["type"] == "const":
+            expr = Expr(
+                ConstNode(
+                    name=node["name"],
+                    value=node["value"],
+                    type=self.str_to_type[node["vartype"]],
+                )
+            )
+        elif node["type"] == "var":
+            expr = Expr(
+                VarNode(
+                    name=node["name"],
+                    shape=node["shape"],
+                    type=self.str_to_type[node["vartype"]],
+                    active=node["active"],
+                )
+            )
+        elif node["type"] == "index":
+            expr = Expr(IndexNode(self._build_expr_index(node["expr"]), node["index"]))
+        elif node["type"] == "passive":
+            expr = Expr(PassiveNode(self._build_expr_index(node["expr"])))
+        elif node["type"] == "unary":
+            expr = Expr(UnaryNode(node["op"], self._build_expr_index(node["expr"])))
+        elif node["type"] == "binary":
+            expr = Expr(
+                BinaryNode(
+                    node["op"],
+                    self._build_expr_index(node["left"]),
+                    self._build_expr_index(node["right"]),
+                )
+            )
+
+        return expr
+
+    def _build_expr_index(self, idx):
+        if self.node_exprs[idx] is not None:
+            return self.node_exprs[idx]
+
+        self.node_exprs[idx] = self._build_expr(idx)
+        return self.node_exprs[idx]
+
+    def _get_expr_type(self, expr, template_name="T__"):
+        shape = _normalize_shape(expr.node.shape)
+        if shape is None:
+            return f"{template_name}"
+        else:
+            if len(shape) == 1:
+                return f"A2D::Vec<{template_name}, {shape[0]}>"
+            elif len(shape) == 2:
+                return f"A2D::Mat<{template_name}, {shape[0]}, {shape[1]}>"
+
+    def _get_ad_type(self, expr, reference=True, mode="eval", template_name="T__"):
+        decl = self._get_expr_type(expr, template_name=template_name)
+        if mode == "eval" or not expr.is_active():
+            return decl
+        elif mode == "grad":
+            if reference:
+                return f"A2D::ADObj<{decl}&>"
+            else:
+                return f"A2D::ADObj<{decl}>"
+        else:
+            if reference:
+                return f"A2D::A2DObj<{decl}&>"
+            else:
+                return f"A2D::A2DObj<{decl}>"
+
+    def _get_declarations(
+        self, inputs, reference=True, mode="eval", template_name="T__"
+    ):
+        lines = []
+
+        for expr in inputs:
+            decl = self._get_ad_type(
+                expr, reference=reference, mode=mode, template_name=template_name
+            )
+            lines.append(f"{decl} {expr.to_cpp()}")
+
+        return lines
+
+    def _get_input_declarations(
+        self,
+        inputs,
+        mode="eval",
+        template_name="T__",
+        input_name="input__",
+        grad_name="boutput__",
+        prod_name="pinput__",
+        hprod_name="houtput__",
+    ):
+        lines = []
+
+        for index, expr in enumerate(inputs):
+            decl = self._get_ad_type(expr, mode=mode, template_name=template_name)
+
+            line = f"{decl} {expr.to_cpp()}"
+            if mode == "eval":
+                line = f"{line} = A2D::get<{index}>({input_name})"
+            elif mode == "grad":
+                line = f"{line} = {decl}(A2D::get<{index}>({input_name}), A2D::get<{index}>({grad_name}))"
+            else:
+                line = (
+                    f"{line} = "
+                    + f"{decl}(A2D::get<{index}>({input_name}), A2D::get<{index}>({grad_name}), "
+                    + f"A2D::get<{index}>({prod_name}), A2D::get<{index}>({hprod_name}))"
+                )
+            lines.append(line)
+
+        return lines
+
+    def get_cpp_lines(
+        self,
+        mode="eval",
+        template_name="T__",
+        data_name="data__",
+        input_name="input__",
+        grad_name="boutput__",
+        prod_name="pinput__",
+        hprod_name="houtput__",
+    ):
+        """Make the expressions"""
+
+        decl = []
+        passive = []
+        active = []
+
+        # Get lines for the data - note that we use the data name here
+        decl = self._get_input_declarations(
+            self.data, mode=mode, template_name=template_name, input_name=data_name
+        )
+
+        # Get the declaration lines for the input
+        decl.extend(
+            self._get_input_declarations(
+                self.inputs,
+                mode=mode,
+                template_name=template_name,
+                input_name=input_name,
+                grad_name=grad_name,
+                prod_name=prod_name,
+                hprod_name=hprod_name,
+            )
+        )
+
+        # Get the declaration lines for the temporaries
+        temps = [t for t, _ in self.temp_exprs]
+        decl.extend(
+            self._get_declarations(
+                temps,
+                reference=False,
+                mode=mode,
+                template_name=template_name,
+            )
+        )
+
+        # Now construct lines for the passive and active terms
+        make_passive = lambda name, rhs: f"{name} = {rhs}"
+        if mode == "eval":
+            make_active = lambda name, rhs: f"{name} = {rhs}"
+        else:
+            make_active = lambda name, rhs: f"A2D::Eval({rhs}, {name})"
+
+        # Add the passive lines to the code
+        for var, rhs in self.temp_exprs:
+            if not var.is_active():
+                passive.append(make_passive(var.to_cpp(), rhs.to_cpp()))
+
+        # Add the active lines to the code
+        for var, rhs in self.temp_exprs:
+            if var.is_active():
+                active.append(make_active(var.to_cpp(), rhs.to_cpp()))
+
+        # Add the new expressions
+        for lhs, rhs in zip(self.lhs, self.new_rhs):
+            active.append(make_active(lhs.to_cpp(), rhs.to_cpp()))
+
+        return decl, passive, active

--- a/amigo/expressions.py
+++ b/amigo/expressions.py
@@ -273,6 +273,12 @@ class Expr:
                     raise ValueError(f"Index {index} out of range")
 
             return Expr(IndexNode(self, index))
+        elif isinstance(self.node, PassiveNode):
+            if isinstance(idx, tuple):
+                index = tuple(int(i) for i in idx)
+            else:
+                index = int(idx)
+            return Expr(IndexNode(self, index))
         else:
             raise TypeError("You can only index variables, not general expressions")
 
@@ -380,7 +386,7 @@ class ExprBuilder:
 
         # Set it up so that the temp expressions are in order
         self.temp_exprs = []
-        for idx in sorted(self.temp_list):
+        for idx in sorted(set(self.temp_list)):
             # Set whether the temporaries are active or not
             self.node_exprs[idx].set_active_flag(temp_var_exprs[idx].is_active())
             self.temp_exprs.append([self.node_exprs[idx], temp_var_exprs[idx]])

--- a/amigo/model.py
+++ b/amigo/model.py
@@ -1100,7 +1100,6 @@ amigo_add_python_module(
 
         # Locate the installed Amigo CMake package inside the Python package
         amigo_cmake_dir = get_cmake_dir()
-        print("amigo_cmake_dir = ", amigo_cmake_dir)
 
         # Cmake command
         cmake_cmd = [

--- a/amigo/unary_operations.py
+++ b/amigo/unary_operations.py
@@ -1,116 +1,123 @@
-import math
-from .expressions import Expr, UnaryNode, OpNode, ConstNode, PassiveNode
+from expressions import Expr, VarNode, UnaryNode, BinaryNode, ConstNode, PassiveNode
 
 
 def abs(expr):
-    return Expr(UnaryNode("fabs", math.fabs, expr.node))
+    return Expr(UnaryNode("fabs", expr))
 
 
 def fabs(expr):
-    return Expr(UnaryNode("fabs", math.fabs, expr.node))
+    return Expr(UnaryNode("fabs", expr))
 
 
 def sqrt(expr):
-    return Expr(UnaryNode("sqrt", math.sqrt, expr.node))
+    return Expr(UnaryNode("sqrt", expr))
 
 
 def sin(expr):
-    return Expr(UnaryNode("sin", math.sin, expr.node))
+    return Expr(UnaryNode("sin", expr))
 
 
 def sqrt(expr):
-    return Expr(UnaryNode("sqrt", math.sqrt, expr.node))
+    return Expr(UnaryNode("sqrt", expr))
 
 
 def asin(expr):
-    return Expr(UnaryNode("asin", math.asin, expr.node))
+    return Expr(UnaryNode("asin", expr))
 
 
 def cos(expr):
-    return Expr(UnaryNode("cos", math.cos, expr.node))
+    return Expr(UnaryNode("cos", expr))
 
 
 def acos(expr):
-    return Expr(UnaryNode("acos", math.acos, expr.node))
+    return Expr(UnaryNode("acos", expr))
 
 
 def tan(expr):
-    return Expr(UnaryNode("tan", math.tan, expr.node))
+    return Expr(UnaryNode("tan", expr))
 
 
 def atan(expr):
-    return Expr(UnaryNode("atan", math.atan, expr.node))
+    return Expr(UnaryNode("atan", expr))
 
 
 def sinh(expr):
-    return Expr(UnaryNode("sinh", math.sinh, expr.node))
+    return Expr(UnaryNode("sinh", expr))
 
 
 def asinh(expr):
-    return Expr(UnaryNode("asinh", math.asinh, expr.node))
+    return Expr(UnaryNode("asinh", expr))
 
 
 def cosh(expr):
-    return Expr(UnaryNode("cosh", math.cosh, expr.node))
+    return Expr(UnaryNode("cosh", expr))
 
 
 def acosh(expr):
-    return Expr(UnaryNode("acosh", math.acosh, expr.node))
+    return Expr(UnaryNode("acosh", expr))
 
 
 def tanh(expr):
-    return Expr(UnaryNode("tanh", math.tanh, expr.node))
+    return Expr(UnaryNode("tanh", expr))
 
 
 def atanh(expr):
-    return Expr(UnaryNode("atanh", math.atanh, expr.node))
+    return Expr(UnaryNode("atanh", expr))
 
 
 def exp(expr):
-    return Expr(UnaryNode("exp", math.exp, expr.node))
+    return Expr(UnaryNode("exp", expr))
 
 
 def log(expr):
-    return Expr(UnaryNode("log", math.log, expr.node))
+    return Expr(UnaryNode("log", expr))
 
 
 def log10(expr):
-    return Expr(UnaryNode("log10", math.log10, expr.node))
+    return Expr(UnaryNode("log10", expr))
 
 
 def atan2(a, b):
     if isinstance(a, (int, float)) and isinstance(b, (int, float)):
         raise ValueError("Neither argument is active")
     elif isinstance(a, (int, float)):
-        return Expr(OpNode("atan2", ConstNode(value=a), b.node))
+        return Expr(BinaryNode("atan2", ConstNode(value=a), b))
     elif isinstance(b, (int, float)):
-        return Expr(OpNode("atan2", a.node, ConstNode(value=b)))
+        return Expr(BinaryNode("atan2", a, ConstNode(value=b)))
+    elif isinstance(a, Expr) and isinstance(b, Expr):
+        return Expr(BinaryNode("atan2", a, b))
     else:
-        return Expr(OpNode("atan2", a.node, b.node))
+        raise TypeError("Types not recognized for atan2")
 
 
 def min2(a, b):
     if isinstance(a, (int, float)) and isinstance(b, (int, float)):
         raise ValueError("Neither argument is active")
     elif isinstance(a, (int, float)):
-        return Expr(OpNode("min2", ConstNode(value=a), b.node))
+        return Expr(BinaryNode("min2", ConstNode(value=a), b))
     elif isinstance(b, (int, float)):
-        return Expr(OpNode("min2", a.node, ConstNode(value=b)))
+        return Expr(BinaryNode("min2", a, ConstNode(value=b)))
+    elif isinstance(a, Expr) and isinstance(b, Expr):
+        return Expr(BinaryNode("min2", a, b))
     else:
-        return Expr(OpNode("min2", a.node, b.node))
+        raise TypeError("Types not recognized for min2")
 
 
 def max2(a, b):
     if isinstance(a, (int, float)) and isinstance(b, (int, float)):
         raise ValueError("Neither argument is active")
     elif isinstance(a, (int, float)):
-        return Expr(OpNode("max2", ConstNode(value=a), b.node))
+        return Expr(BinaryNode("max2", ConstNode(value=a), b))
     elif isinstance(b, (int, float)):
-        return Expr(OpNode("max2", a.node, ConstNode(value=b)))
+        return Expr(BinaryNode("max2", a, ConstNode(value=b)))
+    elif isinstance(a, Expr) and isinstance(b, Expr):
+        return Expr(BinaryNode("max2", a, b))
     else:
-        return Expr(OpNode("max2", a.node, b.node))
+        raise TypeError("Types not recognized for max2")
 
 
 def passive(expr):
     """Force an expression to be passive"""
+    if not isinstance(expr.node, VarNode):
+        raise TypeError("Passive type must be a variable")
     return Expr(PassiveNode(expr))

--- a/amigo/unary_operations.py
+++ b/amigo/unary_operations.py
@@ -1,4 +1,4 @@
-from expressions import Expr, VarNode, UnaryNode, BinaryNode, ConstNode, PassiveNode
+from .expressions import Expr, VarNode, UnaryNode, BinaryNode, ConstNode, PassiveNode
 
 
 def abs(expr):

--- a/examples/cart/cart_pole.py
+++ b/examples/cart/cart_pole.py
@@ -327,8 +327,6 @@ if args.build:
 comm = COMM_WORLD
 model.initialize(comm=comm)
 
-exit(0)
-
 comm_rank = 0
 distribute = False
 if comm is not None:

--- a/examples/cart/cart_pole.py
+++ b/examples/cart/cart_pole.py
@@ -327,6 +327,8 @@ if args.build:
 comm = COMM_WORLD
 model.initialize(comm=comm)
 
+exit(0)
+
 comm_rank = 0
 distribute = False
 if comm is not None:

--- a/examples/cart/cart_pole.py
+++ b/examples/cart/cart_pole.py
@@ -74,8 +74,8 @@ class CartComponent(am.Component):
         qdot = self.inputs["qdot"]
 
         # Compute the declared variable values
-        sint = self.vars["sint"] = am.sin(q[1])
-        cost = self.vars["cost"] = am.cos(q[1])
+        sint = am.sin(q[1])
+        cost = am.cos(q[1])
 
         res = 4 * [None]
         # Kinematic constraints

--- a/examples/nozzle/nozzle.py
+++ b/examples/nozzle/nozzle.py
@@ -32,17 +32,55 @@ class RoeFlux(am.Component):
         # Compute the weights
         rhoL = QL[0]
         rhoR = QR[0]
-        r = self.vars["r"] = am.sqrt(rhoR / rhoL)
-        wL = self.vars["wL"] = r / (r + 1.0)
-        wR = self.vars["wR"] = 1.0 - wL
+        # r = self.vars["r"] = am.sqrt(rhoR / rhoL)
+        # wL = self.vars["wL"] = r / (r + 1.0)
+        # wR = self.vars["wR"] = 1.0 - wL
+
+        # # Compute the left and right states
+        # uL = self.vars["uL"] = QL[1] / QL[0]
+        # pL = self.vars["pL"] = gam1 * (QL[2] - 0.5 * rhoL * uL * uL)
+        # HL = ggam1 * (pL / rhoL) + 0.5 * uL * uL
+
+        # uR = self.vars["uR"] = QR[1] / QR[0]
+        # pR = self.vars["pR"] = gam1 * (QR[2] - 0.5 * rhoR * uR * uR)
+        # HR = ggam1 * (pR / rhoR) + 0.5 * uR * uR
+
+        # # Compute the left and right fluxes
+        # FL = [rhoL * uL, rhoL * uL * uL + pL, rhoL * HL * uL]
+        # FR = [rhoR * uR, rhoR * uR * uR + pR, rhoR * HR * uR]
+
+        # # Compute the Roe averages
+        # rho = self.vars["rho"] = r * rhoL
+        # u = self.vars["u"] = wL * uL + wR * uR
+        # H = self.vars["H"] = wL * HL + wR * HR
+
+        # a = self.vars["a"] = am.sqrt(gam1 * (H - 0.5 * u * u))
+        # ainv = self.vars["ainv"] = 1.0 / a
+
+        # fp = self.vars["fp"] = ainv * ainv * (pR - pL)
+        # fu = self.vars["fu"] = (uR - uL) * rho * ainv
+
+        # # Entropy fix with a square root function
+        # h = self.vars["h"] = 0.05 * (am.abs(u) + a)
+        # lam1 = self.vars["lam1"] = am.sqrt(u * u + h * h / 4)
+        # lam2 = self.vars["lam2"] = am.sqrt((u + a) * (u + a) + h * h / 4)
+        # lam3 = self.vars["lam3"] = am.sqrt((u - a) * (u - a) + h * h / 4)
+
+        # w0 = self.vars["w0"] = ((rhoR - rhoL) - fp) * lam1
+        # w1 = self.vars["w1"] = (0.5 * (fp + fu)) * lam2
+        # w2 = self.vars["w2"] = (0.5 * (fp - fu)) * lam3
+
+        r = am.sqrt(rhoR / rhoL)
+        wL = r / (r + 1.0)
+        wR = 1.0 - wL
 
         # Compute the left and right states
-        uL = self.vars["uL"] = QL[1] / QL[0]
-        pL = self.vars["pL"] = gam1 * (QL[2] - 0.5 * rhoL * uL * uL)
+        uL = QL[1] / QL[0]
+        pL = gam1 * (QL[2] - 0.5 * rhoL * uL * uL)
         HL = ggam1 * (pL / rhoL) + 0.5 * uL * uL
 
-        uR = self.vars["uR"] = QR[1] / QR[0]
-        pR = self.vars["pR"] = gam1 * (QR[2] - 0.5 * rhoR * uR * uR)
+        uR = QR[1] / QR[0]
+        pR = gam1 * (QR[2] - 0.5 * rhoR * uR * uR)
         HR = ggam1 * (pR / rhoR) + 0.5 * uR * uR
 
         # Compute the left and right fluxes
@@ -50,25 +88,25 @@ class RoeFlux(am.Component):
         FR = [rhoR * uR, rhoR * uR * uR + pR, rhoR * HR * uR]
 
         # Compute the Roe averages
-        rho = self.vars["rho"] = r * rhoL
-        u = self.vars["u"] = wL * uL + wR * uR
-        H = self.vars["H"] = wL * HL + wR * HR
+        rho = r * rhoL
+        u = wL * uL + wR * uR
+        H = wL * HL + wR * HR
 
-        a = self.vars["a"] = am.sqrt(gam1 * (H - 0.5 * u * u))
-        ainv = self.vars["ainv"] = 1.0 / a
+        a = am.sqrt(gam1 * (H - 0.5 * u * u))
+        ainv = 1.0 / a
 
-        fp = self.vars["fp"] = ainv * ainv * (pR - pL)
-        fu = self.vars["fu"] = (uR - uL) * rho * ainv
+        fp = ainv * ainv * (pR - pL)
+        fu = (uR - uL) * rho * ainv
 
         # Entropy fix with a square root function
-        h = self.vars["h"] = 0.05 * (am.abs(u) + a)
-        lam1 = self.vars["lam1"] = am.sqrt(u * u + h * h / 4)
-        lam2 = self.vars["lam2"] = am.sqrt((u + a) * (u + a) + h * h / 4)
-        lam3 = self.vars["lam3"] = am.sqrt((u - a) * (u - a) + h * h / 4)
+        h = 0.05 * (am.abs(u) + a)
+        lam1 = am.sqrt(u * u + h * h / 4)
+        lam2 = am.sqrt((u + a) * (u + a) + h * h / 4)
+        lam3 = am.sqrt((u - a) * (u - a) + h * h / 4)
 
-        w0 = self.vars["w0"] = ((rhoR - rhoL) - fp) * lam1
-        w1 = self.vars["w1"] = (0.5 * (fp + fu)) * lam2
-        w2 = self.vars["w2"] = (0.5 * (fp - fu)) * lam3
+        w0 = ((rhoR - rhoL) - fp) * lam1
+        w1 = (0.5 * (fp + fu)) * lam2
+        w2 = (0.5 * (fp - fu)) * lam3
 
         Fr = 0.5 * w0 * u * u + w1 * (H + u * a) + w2 * (H - u * a)
         self.constraints["res"] = [
@@ -343,10 +381,13 @@ class PseudoTransient(am.Component):
         Q = self.inputs["Q"]
         CFL = self.data["CFL"]
 
-        rho = self.vars["rho"] = am.passive(Q[0])
-        q1 = self.vars["q1"] = am.passive(Q[1])
-        q2 = self.vars["q2"] = am.passive(Q[2])
+        # Extract passive values - this won't be differentiated
+        Qp = am.passive(Q)
+        rho = Qp[0]
+        q1 = Qp[1]
+        q2 = Qp[2]
 
+        # Compute the time step
         u = self.vars["u"] = q1 / rho
         p = self.vars["p"] = gam1 * (q2 - 0.5 * rho * u * u)
         a = am.sqrt(gamma * p / rho)


### PR DESCRIPTION
- ExprBuilder class automatically serializes/simplifies Expr objects
- Expressions with duplicate subtrees are simplified by adding temporary variables
- self.vars exists still, but it's use should be deprecated (or limited?)
- Cart, nozzle and helmholtz examples updated