### PR TITLE
Symmetric BCs Merge

### DIFF
--- a/amigo/fem/basis.py
+++ b/amigo/fem/basis.py
@@ -435,19 +435,19 @@ class TriangleQuadrature(Quadrature):
             # 1-point (exact for degree 1)
             self.xi = np.array([1 / 3])
             self.eta = np.array([1 / 3])
-            self.weights = np.array([1.0])
+            self.weights = np.array([1.0 / 2.0])
 
         elif order == 2:
             # 3-point (exact for degree 2)
             self.xi = np.array([1 / 6, 2 / 3, 1 / 6])
             self.eta = np.array([1 / 6, 1 / 6, 2 / 3])
-            self.weights = np.array([1 / 3, 1 / 3, 1 / 3])
+            self.weights = np.array([1 / 6, 1 / 6, 1 / 6])
 
         elif order == 3:
             # 4-point (exact for degree 3)
-            self.xi = np.array([1 / 3, 0.2, 0.2, 0.6])
-            self.eta = np.array([1 / 3, 0.2, 0.6, 0.2])
-            self.weights = np.array([-27 / 48, 25 / 48, 25 / 48, 25 / 48])
+            self.xi = np.array([1 / 3, 3 / 5, 1 / 5, 1 / 5])
+            self.eta = np.array([1 / 3, 1 / 5, 3 / 5, 1 / 5])
+            self.weights = np.array([-9 / 32, 25 / 96, 25 / 96, 25 / 96])
 
         elif order == 4:
             a = 0.445948490915965

--- a/amigo/fem/basis.py
+++ b/amigo/fem/basis.py
@@ -493,7 +493,8 @@ class QuadQuadrature(Quadrature):
         wt = self.weights[n] * self.weights[m]
         pt = [self.points[n], self.points[m]]
         return wt, pt
-    
+
+
 class ReducedQuadQuadrature(Quadrature):
     def __init__(self):
         self.args = [{"n": 0, "m": 0}]

--- a/amigo/fem/fem.py
+++ b/amigo/fem/fem.py
@@ -28,7 +28,7 @@ class DofSource(am.Component):
 
 
 class SymmBCSource(am.Component):
-    def __init__(self, input_name=[], scale=[1.0, 1.0]):
+    def __init__(self, input_name=[], scale=[]):
         super().__init__()
 
         self.input_name = input_name
@@ -59,19 +59,32 @@ class SymmetryDegreesOfFreedom:
         self.bc = bc
         return
 
-    def _get_bc_nodes(self, targets, start=True, end=True):
+    def _get_bc_nodes(self, targets, start, end):
         all_nodes = []
         for target in targets:
             nodes = self.mesh.get_bc_nodes(target, "T3D2")
-
-            if not start:
-                nodes = nodes[1:]
-            if not end:
-                nodes = nodes[:-1]
-
             all_nodes.extend(nodes)
 
-        return list(dict.fromkeys(all_nodes))  # preserve order
+        unique = list(dict.fromkeys(all_nodes))  # preserve order
+
+        if not start:
+            unique = unique[1:]
+        if not end:
+            unique = unique[:-1]
+
+        return unique
+
+    def _reorder_nodes(self, nodes_left, nodes_right):
+        nodes_left = np.array(nodes_left)
+        nodes_right = np.array(nodes_right)
+
+        y_left = self.mesh.X[nodes_left, 1]
+        y_right = self.mesh.X[nodes_right, 1]
+
+        idx_left = np.argsort(y_left)
+        idx_right = np.argsort(y_right)
+
+        return nodes_left[idx_left], nodes_right[idx_right]
 
     def add_and_link_source(self, model):
         targets = self.bc["target"]
@@ -82,33 +95,35 @@ class SymmetryDegreesOfFreedom:
 
         left_target_lines = targets[0]
         right_target_lines = targets[1]
-        nodes_left = self._get_bc_nodes(left_target_lines, start=start, end=end)
-        nodes_right = self._get_bc_nodes(right_target_lines, start=start, end=end)
+        nodes_left = self._get_bc_nodes(left_target_lines, start, end)
+        nodes_right = self._get_bc_nodes(right_target_lines, start, end)
 
         if len(nodes_left) != len(nodes_right):
             raise Exception(f"nnodes left != nnodes right")
+
+        # Reorder the nodes to match
+        nodes_a, nodes_b = self._reorder_nodes(nodes_left, nodes_right)
 
         bc_src = SymmBCSource(input_names, scale=scale)
 
         if len(nodes_left) > 0:
             for name in input_names:
-                for name in input_names:
-                    model.add_component(
-                        f"src_{name}",
-                        len(nodes_left),
-                        bc_src,
-                    )
+                model.add_component(
+                    f"src_{self.bc_name}",
+                    len(nodes_left),
+                    bc_src,
+                )
 
-                    model.link(
-                        f"src_soln.{name}",
-                        f"src_{self.bc_name}.{name}0",
-                        src_indices=nodes_left,
-                    )
-                    model.link(
-                        f"src_soln.{name}",
-                        f"src_{self.bc_name}.{name}1",
-                        src_indices=nodes_right,
-                    )
+                model.link(
+                    f"src_soln.{name}",
+                    f"src_{self.bc_name}.{name}0",
+                    src_indices=nodes_a,
+                )
+                model.link(
+                    f"src_soln.{name}",
+                    f"src_{self.bc_name}.{name}1",
+                    src_indices=nodes_b,
+                )
         return
 
 
@@ -137,7 +152,7 @@ class DirichletDegreesOfFreedom:
         self.bc = bc
         return
 
-    def _get_bc_nodes(self, targets, start=True, end=True):
+    def _get_bc_nodes(self, targets, start, end):
         all_nodes = []
         for target in targets:
             nodes = self.mesh.get_bc_nodes(target, "T3D2")
@@ -155,7 +170,7 @@ class DirichletDegreesOfFreedom:
         targets = self.bc["target"]
         start = self.bc["start"]
         end = self.bc["end"]
-        nodes = self._get_bc_nodes(targets, start=start, end=end)
+        nodes = self._get_bc_nodes(targets, start, end)
 
         input_names = self.bc["input"]
         bc_src = DirichletBCSource(input_name=input_names)
@@ -332,10 +347,8 @@ class Mesh:
     def get_num_surfaces(self):
         return self.parser.get_num_surfaces()
 
-    def get_bc_nodes(self, name, etype, flip=False):
+    def get_bc_nodes(self, name, etype):
         conn = self.parser.get_edge_node(name, etype)
-        if flip == True:
-            np.flip(conn)
         return conn
 
     def get_num_nodes_on_bc(self, name, etype):
@@ -437,6 +450,22 @@ class Mesh:
 
         return np.vstack(cs)
 
+    def plot_tri_mesh_region(self, name, etype, ax, color, label):
+        X2d = self.X[:, 0:2]  # Reduce to 2d (x,y coords only)
+        gmsh_conn = self.get_conn(name, etype)
+        polygons = [X2d[row] for row in gmsh_conn]
+
+        coll = PolyCollection(
+            polygons,
+            facecolors=color,
+            edgecolors="k",
+            linewidths=0.01,
+            label=label,
+            antialiaseds=False,
+        )
+        ax.add_collection(coll)
+        return
+
 
 # Needs to take in bcs here
 class Problem:
@@ -492,6 +521,8 @@ class Problem:
                 )
             elif bc["type"] == "symmetry":
                 self.symm_dof.append(SymmetryDegreesOfFreedom(name, self.mesh, bc))
+            else:
+                raise Exception(f"{bc["type"]} not recognized")
 
         return
 
@@ -562,10 +593,8 @@ class Problem:
         for dof in self.dirichlet_dof:
             dof.add_and_link_source(model)
 
-        # Add symmetric bcs
-        # for dof in self.symm_dof:
-        #     dof.add_bc_source(model)
-        #     dof.link_bc_dof(model)
+        for dof in self.symm_dof:
+            dof.add_and_link_source(model)
 
         # Make a list of all of the outputs
         all_outputs = []

--- a/amigo/fem/fem.py
+++ b/amigo/fem/fem.py
@@ -176,12 +176,12 @@ class DirichletDegreesOfFreedom:
         bc_src = DirichletBCSource(input_name=input_names)
 
         if len(nodes) > 0:
+            model.add_component(
+                f"src_{self.bc_name}",
+                len(nodes),
+                bc_src,
+            )
             for name in input_names:
-                model.add_component(
-                    f"src_{self.bc_name}",
-                    len(nodes),
-                    bc_src,
-                )
 
                 model.link(
                     f"src_soln.{name}",

--- a/amigo/fem/fem.py
+++ b/amigo/fem/fem.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 import matplotlib.tri as mtri
 from matplotlib.collections import PolyCollection
 
+
 class DofSource(am.Component):
     def __init__(self, input_names=[], data_names=[], con_names=[], output_names=[]):
         super().__init__()
@@ -413,6 +414,7 @@ class Mesh:
                 ax.set_aspect("equal")
                 # fig.colorbar(cntr, ax=ax)
         return ax
+
     def plot_3d(
         self,
         w,
@@ -430,7 +432,7 @@ class Mesh:
     ):
         """
         Plot the 2D mesh lifted into 3D by the out-of-plane displacement field w.
- 
+
         Parameters
         ----------
         w         : (nnodes,) array — perpendicular displacement at each node
@@ -448,31 +450,31 @@ class Mesh:
         from mpl_toolkits.mplot3d.art3d import Poly3DCollection
         import matplotlib.cm as cm
         import matplotlib.colors as mcolors
- 
+
         if fig is None or ax is None:
             fig = plt.figure(figsize=(10, 7))
             ax = fig.add_subplot(111, projection="3d")
- 
+
         x = self.X[:, 0] + x_offset
         y = self.X[:, 1] + y_offset
         z = np.asarray(w) * scale
- 
+
         # Colormap normalisation
         vmin = np.min(z) if min_level is None else min_level * scale
         vmax = np.max(z) if max_level is None else max_level * scale
         norm = mcolors.Normalize(vmin=vmin, vmax=vmax)
         scalar_map = cm.ScalarMappable(norm=norm, cmap=cmap)
- 
+
         volumes = self.get_domains()
- 
+
         for name in volumes:
             for etype in volumes[name]:
                 if etype == "T3D2":
                     continue
- 
+
                 # Triangulate so we can colour per-triangle face
                 tri_conn = self.convert_conn(etype, self.get_conn(name, etype))
- 
+
                 verts = []
                 face_colors = []
                 for tri in tri_conn:
@@ -480,7 +482,7 @@ class Mesh:
                     verts.append(pts)
                     # colour by mean displacement of the triangle
                     face_colors.append(scalar_map.to_rgba(np.mean(z[tri])))
- 
+
                 poly = Poly3DCollection(
                     verts,
                     facecolors=face_colors,
@@ -489,22 +491,23 @@ class Mesh:
                     alpha=alpha,
                 )
                 ax.add_collection3d(poly)
- 
+
         # Axis limits derived from data
         ax.set_xlim(x.min(), x.max())
         ax.set_ylim(y.min(), y.max())
         ax.set_zlim(vmin, vmax)
- 
+
         ax.set_xlabel("X")
         ax.set_ylabel("Y")
         ax.set_zlabel("w")
- 
+
         if title is not None:
             ax.set_title(title)
- 
+
         fig.colorbar(scalar_map, ax=ax, shrink=0.5, label="w")
- 
+
         return ax
+
     def convert_conn(self, etype, conn):
         if etype == "CPS3":
             return conn
@@ -649,15 +652,14 @@ class Problem:
                 soln_basis = self.soln_dof.get_basis(etype)
                 data_basis = self.data_dof.get_basis(etype)
                 geo_basis = self.geo_dof.get_basis(etype)
-                
 
                 # quadrature = self.soln_dof.get_quadrature(etype)
                 # # Create the quadrature instance
-                if weakform_name == 'bending_potential':
+                if weakform_name == "bending_potential":
                     quadrature = basis.ReducedQuadQuadrature()
-                else: 
+                else:
                     quadrature = self.soln_dof.get_quadrature(etype)
-                    
+
                 # Create the element object
                 obj = FiniteElement(
                     elem_name, soln_basis, data_basis, geo_basis, quadrature, weakform
@@ -800,9 +802,6 @@ class FiniteElement(am.Component):
     def compute(self, **args):
 
         quad_weight, quad_point = self.quadrature.get_point(**args)
-
-        print(quad_weight)
-        print(quad_point)
 
         # Evaluate the solution fields/data fields (u)
         soln_xi = self.soln_basis.eval(self, quad_point)

--- a/amigo/fem/fem.py
+++ b/amigo/fem/fem.py
@@ -7,7 +7,6 @@ import matplotlib.pyplot as plt
 import matplotlib.tri as mtri
 from matplotlib.collections import PolyCollection
 
-
 class DofSource(am.Component):
     def __init__(self, input_names=[], data_names=[], con_names=[], output_names=[]):
         super().__init__()
@@ -414,7 +413,98 @@ class Mesh:
                 ax.set_aspect("equal")
                 # fig.colorbar(cntr, ax=ax)
         return ax
-
+    def plot_3d(
+        self,
+        w,
+        fig=None,
+        ax=None,
+        scale=1.0,
+        cmap="coolwarm",
+        title=None,
+        x_offset=0.0,
+        y_offset=0.0,
+        alpha=0.85,
+        show_edges=True,
+        min_level=None,
+        max_level=None,
+    ):
+        """
+        Plot the 2D mesh lifted into 3D by the out-of-plane displacement field w.
+ 
+        Parameters
+        ----------
+        w         : (nnodes,) array — perpendicular displacement at each node
+        fig/ax    : existing Figure / Axes3D to draw into (created if None)
+        scale     : multiply w before plotting (useful for visual exaggeration)
+        cmap      : matplotlib colormap name
+        title     : axes title string
+        x_offset  : shift all x coordinates before plotting
+        y_offset  : shift all y coordinates before plotting
+        alpha     : surface transparency
+        show_edges: overlay mesh wire-frame on the surface
+        min_level / max_level : clamp the colormap range
+        """
+        from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 — registers 3d projection
+        from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+        import matplotlib.cm as cm
+        import matplotlib.colors as mcolors
+ 
+        if fig is None or ax is None:
+            fig = plt.figure(figsize=(10, 7))
+            ax = fig.add_subplot(111, projection="3d")
+ 
+        x = self.X[:, 0] + x_offset
+        y = self.X[:, 1] + y_offset
+        z = np.asarray(w) * scale
+ 
+        # Colormap normalisation
+        vmin = np.min(z) if min_level is None else min_level * scale
+        vmax = np.max(z) if max_level is None else max_level * scale
+        norm = mcolors.Normalize(vmin=vmin, vmax=vmax)
+        scalar_map = cm.ScalarMappable(norm=norm, cmap=cmap)
+ 
+        volumes = self.get_domains()
+ 
+        for name in volumes:
+            for etype in volumes[name]:
+                if etype == "T3D2":
+                    continue
+ 
+                # Triangulate so we can colour per-triangle face
+                tri_conn = self.convert_conn(etype, self.get_conn(name, etype))
+ 
+                verts = []
+                face_colors = []
+                for tri in tri_conn:
+                    pts = np.column_stack([x[tri], y[tri], z[tri]])  # (3, 3)
+                    verts.append(pts)
+                    # colour by mean displacement of the triangle
+                    face_colors.append(scalar_map.to_rgba(np.mean(z[tri])))
+ 
+                poly = Poly3DCollection(
+                    verts,
+                    facecolors=face_colors,
+                    edgecolors="k" if show_edges else "none",
+                    linewidths=0.3 if show_edges else 0.0,
+                    alpha=alpha,
+                )
+                ax.add_collection3d(poly)
+ 
+        # Axis limits derived from data
+        ax.set_xlim(x.min(), x.max())
+        ax.set_ylim(y.min(), y.max())
+        ax.set_zlim(vmin, vmax)
+ 
+        ax.set_xlabel("X")
+        ax.set_ylabel("Y")
+        ax.set_zlabel("w")
+ 
+        if title is not None:
+            ax.set_title(title)
+ 
+        fig.colorbar(scalar_map, ax=ax, shrink=0.5, label="w")
+ 
+        return ax
     def convert_conn(self, etype, conn):
         if etype == "CPS3":
             return conn
@@ -559,10 +649,15 @@ class Problem:
                 soln_basis = self.soln_dof.get_basis(etype)
                 data_basis = self.data_dof.get_basis(etype)
                 geo_basis = self.geo_dof.get_basis(etype)
+                
 
-                # Create the quadrature instance
-                quadrature = self.soln_dof.get_quadrature(etype)
-
+                # quadrature = self.soln_dof.get_quadrature(etype)
+                # # Create the quadrature instance
+                if weakform_name == 'bending_potential':
+                    quadrature = basis.ReducedQuadQuadrature()
+                else: 
+                    quadrature = self.soln_dof.get_quadrature(etype)
+                    
                 # Create the element object
                 obj = FiniteElement(
                     elem_name, soln_basis, data_basis, geo_basis, quadrature, weakform
@@ -705,6 +800,9 @@ class FiniteElement(am.Component):
     def compute(self, **args):
 
         quad_weight, quad_point = self.quadrature.get_point(**args)
+
+        print(quad_weight)
+        print(quad_point)
 
         # Evaluate the solution fields/data fields (u)
         soln_xi = self.soln_basis.eval(self, quad_point)

--- a/examples/fem/method_of_manufactured_soln_output/integral.py
+++ b/examples/fem/method_of_manufactured_soln_output/integral.py
@@ -1,0 +1,147 @@
+import numpy as np
+from amigo.fem import dot_product, Problem, Mesh, basis
+import amigo as am
+from scipy.sparse.linalg import spsolve
+import matplotlib.pyplot as plt
+import argparse
+
+
+# Method of Manufactured solutions
+def output(soln, data=None, geo=None):
+    u = soln["u"]
+    uvalue = u["value"]
+    return {"integrand": uvalue}
+
+
+def weakform(soln, data=None, geo=None):
+    u = soln["u"]
+    uvalue = u["value"]
+    ugrad = u["grad"]
+    x = geo["x"]["value"]
+    y = geo["y"]["value"]
+
+    f = -2 * np.pi**2 * am.sin(np.pi * x) * am.sin(np.pi * y)
+
+    wf = 0.5 * dot_product(ugrad, ugrad, n=2) - f * uvalue
+    return wf
+
+
+def exact(x, y):
+    return np.sin(np.pi * x) * np.sin(np.pi * y)
+
+
+# Set arguments
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--build", dest="build", action="store_true", default=False, help="Enable building"
+)
+args = parser.parse_args()
+
+# Define mesh objects
+meshes = {"Mesh0": Mesh("plate.inp")}
+
+weakform_map = {
+    "Mesh0": {
+        "air": {"target": ["SURFACE1"], "weakform": weakform},
+    }
+}
+
+bc_map_mesh0 = {
+    "DirichletBC": {
+        "type": "dirichlet",
+        "target": [
+            "LINE1",
+            "LINE2",
+            "LINE3",
+            "LINE4",
+            "LINE5",
+            "LINE6",
+            "LINE7",
+            "LINE8",
+        ],
+        "input": ["u"],
+        "start": True,
+        "end": True,
+    }
+}
+bc_map = {"Mesh0": bc_map_mesh0}
+
+output_map = {
+    "Mesh0": {
+        "integral": {
+            "names": ["integrand"],
+            "target": ["SURFACE1"],
+            "function": output,
+        },
+    }
+}
+
+# Initialize the spaces (same for all domains)
+soln_space = basis.SolutionSpace({"u": "H1"})
+data_space = basis.SolutionSpace({"Jz": "const"})
+geo_space = basis.SolutionSpace({"x": "H1", "y": "H1"})
+
+# Define the global amigo model
+model = am.Model("mms_module")
+
+
+# Create an amigo model for each mesh
+for mesh_name, mesh in meshes.items():
+    problem = Problem(
+        mesh,
+        soln_space,
+        data_space,
+        geo_space,
+        weakform_map=weakform_map[mesh_name],
+        bc_map=bc_map[mesh_name],
+        output_map=output_map[mesh_name],
+    )
+    sub_model = problem.create_model(mesh_name)
+    model.add_model(mesh_name, sub_model)
+
+# Build the model
+if args.build:
+    model.build_module()
+model.initialize(order_type=am.OrderingType.NESTED_DISSECTION)
+p = model.get_problem()
+
+# Set the problem data
+data = model.get_data_vector()
+data["Mesh0.src_geo.x"] = mesh.X[:, 0]
+data["Mesh0.src_geo.y"] = mesh.X[:, 1]
+data["Mesh0.src_data.Jz[0]"] = 10.0
+
+mat = p.create_matrix()
+alpha = 1.0
+x = p.create_vector()
+ans = p.create_vector()
+g = p.create_vector()
+rhs = p.create_vector()
+p.hessian(alpha, x, mat)
+p.gradient(alpha, x, g)
+csr_mat = am.tocsr(mat)
+
+ans.get_array()[:] = spsolve(csr_mat, g.get_array())
+ans_local = ans
+u = ans_local.get_array()[model.get_indices("Mesh0.src_soln.u")]
+
+# Compute the exact solution field
+u_exact = exact(mesh.X[:, 0], mesh.X[:, 1])
+
+# Get the output
+output = model.create_output_vector()
+p.compute_output(ans, output.get_vector())
+exact_integral = 4 / np.pi**2
+amigo_integral = output["Mesh0.outputs.integrand[0]"]
+rel_err = np.abs(exact_integral - amigo_integral) / exact_integral
+norm = np.linalg.norm(u_exact - u)
+print(f"Amigo Integral: {exact_integral:.4e}")
+print(f"Analytic Integral: {amigo_integral:.4e}")
+print(f"Integral Rel. Err.: {rel_err:.4e}")
+print(f"||u_exact - u||: {norm:.4e}")
+
+# Plot the solution field
+# fig, ax = plt.subplots(ncols=2)
+# mesh.plot(u, ax=ax[0])
+# mesh.plot(u_exact, ax=ax[1])
+# plt.show()

--- a/examples/fem/method_of_manufactured_soln_output/mesh.py
+++ b/examples/fem/method_of_manufactured_soln_output/mesh.py
@@ -1,0 +1,35 @@
+import gmsh
+import sys
+
+gmsh.initialize()
+gmsh.model.add("plate")
+lc = 0.005
+L = 1.0  # length of a segment
+
+# Geometry points rectangle
+gmsh.model.geo.addPoint(0, 0, 0, lc, 1)
+gmsh.model.geo.addPoint(0.5 * L, 0, 0, lc, 2)
+gmsh.model.geo.addPoint(L, 0, 0, lc, 3)
+gmsh.model.geo.addPoint(L, 0.5 * L, 0, lc, 4)
+gmsh.model.geo.addPoint(L, L, 0, lc, 5)
+gmsh.model.geo.addPoint(0.5 * L, L, 0, lc, 6)
+gmsh.model.geo.addPoint(0, L, 0, lc, 7)
+gmsh.model.geo.addPoint(0, 0.5 * L, 0, lc, 8)
+
+gmsh.model.geo.addLine(1, 2, 1)
+gmsh.model.geo.addLine(2, 3, 2)
+gmsh.model.geo.addLine(3, 4, 3)
+gmsh.model.geo.addLine(4, 5, 4)
+gmsh.model.geo.addLine(5, 6, 5)
+gmsh.model.geo.addLine(6, 7, 6)
+gmsh.model.geo.addLine(7, 8, 7)
+gmsh.model.geo.addLine(8, 1, 8)
+
+gmsh.model.geo.addCurveLoop([1, 2, 3, 4, 5, 6, 7, 8], 1)
+gmsh.model.geo.addPlaneSurface([1], 1)
+gmsh.model.geo.synchronize()
+gmsh.model.mesh.generate(2)
+gmsh.write("plate.inp")
+if "-nopopup" not in sys.argv:
+    gmsh.fltk.run()
+gmsh.finalize()

--- a/examples/fem/shells/rm-plate.py
+++ b/examples/fem/shells/rm-plate.py
@@ -159,8 +159,8 @@ w = xm["src_soln.w"]
 tx = xm["src_soln.tx"]
 ty = xm["src_soln.ty"]
 
-np.save('w_reducedshear.npy',w)
-w_shearlocked = np.load('w_shearlocked.npy')
+np.save("w_reducedshear.npy", w)
+w_shearlocked = np.load("w_shearlocked.npy")
 mesh.plot_3d(w)
-print(np.max(np.abs(((w-w_shearlocked)))))
+print(np.max(np.abs(((w - w_shearlocked)))))
 plt.show()

--- a/examples/fem/shells/rm-plate.py
+++ b/examples/fem/shells/rm-plate.py
@@ -153,29 +153,14 @@ print("Solving...")
 K = am.tocsr(mat)
 x.get_array()[:] = spsolve(K, g.get_array())
 
-# # print(np.max(u))
-# # Extract displacement fields
-# ux = u[model.get_indices("src_soln.ux")]
-# uy = u[model.get_indices("src_soln.uy")]
-
-# max_domain = np.max(np.maximum(ux, uy))
-# min_domain = np.min(np.minimum(ux, uy))
-
 print("Plotting...")
 
 w = xm["src_soln.w"]
 tx = xm["src_soln.tx"]
 ty = xm["src_soln.ty"]
 
-# fig, ax = plt.subplots(ncols=3)
-# mesh.plot(w, ax=ax[0])
-# mesh.plot(tx, ax=ax[1])
-# np.save('w_shearlocked.npy', w)
 np.save('w_reducedshear.npy',w)
 w_shearlocked = np.load('w_shearlocked.npy')
 mesh.plot_3d(w)
-# mesh.plot_3d(w_shearlocked)
-
 print(np.max(np.abs(((w-w_shearlocked)))))
-
 plt.show()


### PR DESCRIPTION
- Removed the option for start and end for the dirichlet bc. Start and end have no meaning when np.unique removes duplicates and reorders the nodes.
- Symmetric boundary conditions implemented and working. New method to reorder the nodes to ensure a 1-to-1 mapping.
- Updated triangle quadratures
- Method of manufactured solution integral example. 