### PR TITLE
Remove unreliable inertia from SciPy solver

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ node_modules/
 **/__pycache__
 **/*.pyd
 **/*.so
+**/_amigo_build/
 *.pdf
 *.png
 *.aux

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,22 @@ env/
 /examples/**/*.inp
 /examples/**/*.tex
 /examples/**/*.tikz
+/examples/raceproject/
+/examples/river_crossing/
+*.gif
+*.out
+*.md
+!README.md
+!website/**/*.md
+
+# External dependencies
+extern/
+
+# IDE
+.vscode/
+
+# Docs build
+docs/
 
 # OpenMDAO output
 .openmdao_out

--- a/amigo/optimizer.py
+++ b/amigo/optimizer.py
@@ -3918,7 +3918,9 @@ class Optimizer:
                         filter_monotone_mu = new_mu
                     self.barrier_param = filter_monotone_mu
 
-                elif i > 0 and self.barrier_param > min(tol, compl_inf_tol) / (options["barrier_tol_factor"] + 1.0):
+                elif i > 0 and self.barrier_param > min(tol, compl_inf_tol) / (
+                    options["barrier_tol_factor"] + 1.0
+                ):
                     # Monotone A-3 barrier update
                     kappa_eps = options["barrier_tol_factor"]
                     kappa_mu = options["mu_linear_decrease_factor"]

--- a/amigo/optimizer.py
+++ b/amigo/optimizer.py
@@ -216,18 +216,6 @@ class DirectScipySolver(_HessianDiagMixin):
         """Solve K*x = rhs using existing factorization. Returns numpy array."""
         return self.lu.solve(rhs)
 
-    def get_inertia(self):
-        """Approximate inertia from LU diagonal (heuristic).
-
-        With diag_pivot_thresh=1.0 (strong diagonal pivoting), the signs of
-        U's diagonal approximate the eigenvalue signs of the original matrix.
-        Returns (n_positive, n_negative).
-        """
-        if self.lu is None:
-            raise RuntimeError("Must call factor() before get_inertia()")
-        u_diag = self.lu.U.diagonal()
-        return int(np.sum(u_diag > 0)), int(np.sum(u_diag < 0))
-
 
 class MumpsSolver(_HessianDiagMixin):
     """Sparse symmetric indefinite solver via MUMPS (LDL^T with inertia).

--- a/amigo/optimizer.py
+++ b/amigo/optimizer.py
@@ -925,6 +925,7 @@ class InertiaCorrector:
     def __init__(self, mult_ind, barrier_param, options):
         self.mult_ind = mult_ind
         self._barrier = barrier_param
+        self._verbose = options.get("verbose_barrier", False)
         self.numerical_eps = 1e-12
 
         # Perturbation state
@@ -1238,7 +1239,7 @@ class InertiaCorrector:
                     )
                 return True
 
-            if comm_rank == 0 and not singular:
+            if comm_rank == 0 and not singular and self._verbose:
                 print(
                     f"  Inertia: expected ({n_primal}+, {n_dual}-), "
                     f"got ({n_pos}+, {n_neg}-), "

--- a/amigo/optimizer.py
+++ b/amigo/optimizer.py
@@ -3918,7 +3918,7 @@ class Optimizer:
                         filter_monotone_mu = new_mu
                     self.barrier_param = filter_monotone_mu
 
-                elif i > 0 and self.barrier_param > tol:
+                elif i > 0 and self.barrier_param > min(tol, compl_inf_tol) / (options["barrier_tol_factor"] + 1.0):
                     # Monotone A-3 barrier update
                     kappa_eps = options["barrier_tol_factor"]
                     kappa_mu = options["mu_linear_decrease_factor"]
@@ -3938,12 +3938,14 @@ class Optimizer:
 
                     if should_reduce:
                         if heuristic:
+                            kappa_eps = options["barrier_tol_factor"]
+                            mu_floor = min(tol, compl_inf_tol) / (kappa_eps + 1.0)
                             self.barrier_param, _ = self._compute_barrier_heuristic(
                                 xi_h,
                                 comp_h,
                                 options["heuristic_barrier_gamma"],
                                 options["heuristic_barrier_r"],
-                                tol,
+                                mu_floor,
                             )
                         else:
                             # A-3 monotone with while-loop for multi-step reduction

--- a/examples/cannon/cannon_collocation.py
+++ b/examples/cannon/cannon_collocation.py
@@ -1,3 +1,6 @@
+import os
+
+os.environ["AMIGO_SOLVER"] = "scipy"
 import amigo as am
 import numpy as np
 import argparse
@@ -5,7 +8,6 @@ import json
 import matplotlib.pylab as plt
 import matplotlib.animation as animation
 import niceplots
-
 
 # Assumptions:
 # unit gravity


### PR DESCRIPTION
I was testing if Scipy can have inertia correction, I removed it so inertia correction is skipped when using SciPy, matching the behavior of other solvers without exact LDL^T factorization. Now, you can specify in the code body if you want to use a specific solver, the default order is (Mumps - Pardiso-scipy). But, you can use os.environ["AMIGO_SOLVER"] = "pardiso" or "scipy".