### PR TITLE
Add debug mode, enhance input validation for components, unit testing

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,38 @@
+name: pytest
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout amigo
+        uses: actions/checkout@v4
+
+      - name: Checkout a2d
+        run: git clone --depth 1 https://github.com/smdogroup/a2d.git ../a2d
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libopenmpi-dev libopenblas-dev
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install amigo
+        run: |
+          pip install scikit-build-core pybind11 mpi4py numpy scipy matplotlib
+          pip install -e .
+
+      - name: Install test dependencies
+        run: pip install pytest smt
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,6 +41,10 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install BLAS (Windows)
+        if: runner.os == 'Windows'
+        run: pip install mkl
+
       - name: Install amigo
         run: |
           pip install scikit-build-core pybind11 mpi4py numpy scipy matplotlib

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install BLAS (Windows)
         if: runner.os == 'Windows'
-        run: pip install mkl
+        run: pip install mkl mkl-devel
 
       - name: Install amigo
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Checkout amigo
@@ -16,10 +20,21 @@ jobs:
       - name: Checkout a2d
         run: git clone --depth 1 https://github.com/smdogroup/a2d.git ../a2d
 
-      - name: Install system dependencies
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libopenmpi-dev libopenblas-dev
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install cmake open-mpi openblas
+
+      - name: Install system dependencies (Windows)
+        if: runner.os == 'Windows'
+        uses: mpi4py/setup-mpi@v1
+        with:
+          mpi: msmpi
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ include/amigo_include_paths.h
 *.dll
 /_build_debug
 /amigo/amigo.cpython*
+/**/_amigo_build
 
 # Compiled Python
 **/__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ docs/
 examples/raceproject/
 examples/river_crossing/
 /.claude
+/_build_debug
+*.plist
+*.yml

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ include/amigo_include_paths.h
 *.lib
 *.exp
 *.dll
+/_build_debug
+/amigo/amigo.cpython*
 
 # Compiled Python
 **/__pycache__
@@ -37,6 +39,7 @@ include/amigo_include_paths.h
 # IDE and editor
 .vscode/
 .idea/
+.claude/
 *.swp
 *.swo
 *~
@@ -74,9 +77,6 @@ env/
 # External dependencies
 extern/
 
-# IDE
-.vscode/
-
 # Docs build
 docs/
 
@@ -97,7 +97,3 @@ lib/
 docs/
 examples/raceproject/
 examples/river_crossing/
-/.claude
-/_build_debug
-*.plist
-*.yml

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ lib/
 docs/
 examples/raceproject/
 examples/river_crossing/
+/.claude

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,24 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# ------------------------------------------------
+# Determine build type
+# ------------------------------------------------
+set(AMIGO_DEFAULT_BUILD_TYPE "Release")
+option(AMIGO_ENABLE_SANITIZERS
+       "Enable Address / Undefined Behavior sanitizers" OFF)
+if( NOT CMAKE_CONFIGURATION_TYPES AND 
+      (NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "") )
+  message(STATUS "No build type selected, defaulting to ${AMIGO_DEFAULT_BUILD_TYPE}")
+
+  set(CMAKE_BUILD_TYPE "${AMIGO_DEFAULT_BUILD_TYPE}"
+      CACHE STRING "Choose the type of build" )
+  
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+                "Debug" "Release" "RelWithDebInfo")
+endif()
+message(STATUS "Amigo build type: ${CMAKE_BUILD_TYPE}")
+
 # Set the CUDSS directory
 set(CUDSS_HOME "$ENV{CUDSS_HOME}" CACHE PATH "Path to cuDSS installation")
 
@@ -151,6 +169,24 @@ pybind11_add_module(amigo MODULE
   ${CMAKE_CURRENT_SOURCE_DIR}/amigo/amigo.cpp
 )
 
+# ------------------------------------------------------------------------------
+# Compiler flags per build type (Debug support)
+# ------------------------------------------------------------------------------
+target_compile_options(amigo PRIVATE
+  $<$<CONFIG:Debug>:-O0 -g>
+  $<$<CONFIG:RelWithDebInfo>:-O2 -g>
+  $<$<CONFIG:Release>:-O3>
+)
+if(AMIGO_ENABLE_SANITIZERS)
+  target_compile_options(amigo PRIVATE
+    -fsanitize=address,undefined
+    -fno-omit-frame-pointer
+  )
+  target_link_options(amigo PRIVATE
+    -fsanitize=address,undefined
+  )
+endif()
+
 # Install amigo headers
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
     DESTINATION "${AMIGO_PY_PACKAGE_DIR}/include"
@@ -178,6 +214,11 @@ if(AMIGO_ENABLE_CUDA)
     src/csr_matrix_backend.cu
     src/optimizer_backend.cu
     src/vector_distribute.cu)
+  target_compile_options(backend PRIVATE
+    $<$<CONFIG:Debug>:-O0 -g>
+    $<$<CONFIG:RelWithDebInfo>:-O2 -g>
+    $<$<CONFIG:Release>:-O3>
+  )
   target_link_libraries(backend PUBLIC 
     CUDA::cudart CUDA::cublas CUDA::cublasLt 
     CUDA::cusolver CUDA::cusparse MPI::MPI_CXX)

--- a/amigo/interp/extern_smt.py
+++ b/amigo/interp/extern_smt.py
@@ -58,11 +58,12 @@ class ExternalSMTComponent:
 
         # Evaluate the interpolation constraint
         predict = self.smt.predict_values(inputs)
-        con[:] = predict - outputs
+        con[:] = predict.flatten() - outputs
 
         # Compute the interpolation constraint Jacobian
         for i in range(self.num_inputs):
-            jac[i :: self.num_inputs + 1] = self.smt.predict_derivatives(inputs, i)
+            dpdx = self.smt.predict_derivatives(inputs, i)
+            jac[i :: self.num_inputs + 1] = dpdx.flatten()
         jac[self.num_inputs :: self.num_inputs + 1] = -1
 
         fobj = 0

--- a/amigo/interp/extern_smt.py
+++ b/amigo/interp/extern_smt.py
@@ -15,6 +15,26 @@ class ExternalSMTComponent:
             con[i] = SMT(inputs[i, :]) - outputs[i] = 0
         """
 
+        if not isinstance(num_points, int) or num_points <= 0:
+            raise ValueError(
+                f"num_points must be a positive integer, got {num_points!r}"
+            )
+        if not isinstance(num_inputs, int) or num_inputs <= 0:
+            raise ValueError(
+                f"num_inputs must be a positive integer, got {num_inputs!r}"
+            )
+        if not callable(getattr(smt_model, "predict_values", None)):
+            raise TypeError(
+                f"smt_model must have a callable 'predict_values' method, "
+                f"got {type(smt_model).__name__}"
+            )
+        if not callable(getattr(smt_model, "predict_derivatives", None)):
+            raise TypeError(
+                f"smt_model must have a callable 'predict_derivatives' method, "
+                f"got {type(smt_model).__name__}. "
+                f"Not all SMT model types support derivative evaluation."
+            )
+
         self.num_points = num_points
         self.num_inputs = num_inputs
         self.smt = smt_model

--- a/amigo/model.py
+++ b/amigo/model.py
@@ -520,30 +520,6 @@ class Model:
                 f"'get_constraint_jacobian_csr' method"
             )
 
-        # Check: if a constraint listed here is also declared in a registered Python
-        # component, that component must have an empty compute(). Both the Python component
-        # and the external component accumulate their contributions to the same constraint
-        # index via +=, so a non-empty compute() on the Python side will cause the constraint
-        # to be double-counted, producing incorrect KKT residuals.
-        for con_expr in constraints:
-            parts = con_expr.rsplit(".", 1)
-            if len(parts) == 2:
-                comp_name, con_name = parts
-                if comp_name in self.comp:
-                    py_comp = self.comp[comp_name].comp_obj
-                    if con_name in py_comp.get_constraint_names():
-                        if not py_comp.is_compute_empty():
-                            raise ValueError(
-                                f"add_external_component '{name}': constraint "
-                                f"'{con_expr}' is also declared in Python component "
-                                f"'{comp_name}', which has a non-empty compute(). "
-                                f"Both components accumulate contributions to the same "
-                                f"constraint index, so the constraint will be double-counted "
-                                f"and produce incorrect KKT residuals. The Python component "
-                                f"must have an empty compute() and serve only as a placeholder "
-                                f"to declare the constraint variable and its bounds."
-                            )
-
         self.external_comp[name] = ExternalComponent(
             name, comp_obj, inputs, constraints
         )

--- a/amigo/model.py
+++ b/amigo/model.py
@@ -817,7 +817,7 @@ class Model:
         """
 
         if self.module_name is not None and not self._built:
-            raise RuntimeError(
+            raise Warning(
                 f"Call model.build_module() before model.initialize(). "
                 f"Module '{self.module_name}' has not been compiled in this session."
             )

--- a/amigo/model.py
+++ b/amigo/model.py
@@ -521,9 +521,10 @@ class Model:
             )
 
         # Check: if a constraint listed here is also declared in a registered Python
-        # component, that component must have an empty compute(). If compute() is non-empty,
-        # both the Python side and the external component will write to the same constraint,
-        # causing a segfault in the C++ layer.
+        # component, that component must have an empty compute(). Both the Python component
+        # and the external component accumulate their contributions to the same constraint
+        # index via +=, so a non-empty compute() on the Python side will cause the constraint
+        # to be double-counted, producing incorrect KKT residuals.
         for con_expr in constraints:
             parts = con_expr.rsplit(".", 1)
             if len(parts) == 2:
@@ -536,9 +537,11 @@ class Model:
                                 f"add_external_component '{name}': constraint "
                                 f"'{con_expr}' is also declared in Python component "
                                 f"'{comp_name}', which has a non-empty compute(). "
-                                f"The Python component must have an empty compute() when "
-                                f"an external component handles the constraint — otherwise "
-                                f"both will write to the same constraint, causing a segfault."
+                                f"Both components accumulate contributions to the same "
+                                f"constraint index, so the constraint will be double-counted "
+                                f"and produce incorrect KKT residuals. The Python component "
+                                f"must have an empty compute() and serve only as a placeholder "
+                                f"to declare the constraint variable and its bounds."
                             )
 
         self.external_comp[name] = ExternalComponent(

--- a/amigo/model.py
+++ b/amigo/model.py
@@ -935,7 +935,11 @@ class Model:
 
         if comp_name not in self.comp:
             registered = list(self.comp.keys())
-            hints = [c for c in registered if c.startswith(comp_name + ".") or c.endswith("." + comp_name)]
+            hints = [
+                c
+                for c in registered
+                if c.startswith(comp_name + ".") or c.endswith("." + comp_name)
+            ]
             msg = (
                 f"Component '{comp_name}' not found when resolving '{name}'. "
                 f"Registered components: {registered}"

--- a/amigo/model.py
+++ b/amigo/model.py
@@ -1199,9 +1199,16 @@ class Model:
         comm=COMM_WORLD,
         source_dir: str | Path | None = None,
         build_dir: str | Path | None = None,
+        debug: bool = False,
     ):
         """
         Generate the model code and build it. Additional compile, link arguments and macros can be added here.
+
+        Args:
+            debug (bool): Build with debug symbols and no optimization (CMAKE_BUILD_TYPE=Debug).
+                          Useful for getting meaningful stack traces when the module crashes.
+                          The debug .so is placed in a separate _amigo_build_debug directory
+                          so it does not overwrite a Release build.
         """
 
         comm_rank = 0
@@ -1213,7 +1220,7 @@ class Model:
                 source_dir = self._guess_source_dir()
 
             self.generate_cpp()
-            self._build_module(source_dir=source_dir, build_dir=build_dir)
+            self._build_module(source_dir=source_dir, build_dir=build_dir, debug=debug)
 
         if comm is not None:
             comm.Barrier()
@@ -1291,20 +1298,28 @@ class Model:
         return
 
     def _build_module(
-        self, source_dir: str | Path, build_dir: str | Path | None = None
+        self,
+        source_dir: str | Path,
+        build_dir: str | Path | None = None,
+        debug: bool = False,
     ):
         """
         Build an extension module, utilizing the specified source and build directories.
-        If no build directory is specified, place it in source_dir/_amigo_build.
+        If no build directory is specified, place it in source_dir/_amigo_build (Release)
+        or source_dir/_amigo_build_debug (Debug).
 
         Args:
             source_dir (str or Path): Location of the source for the module
             build_dir (str, Path or None): Location of the build directory
+            debug (bool): Build with CMAKE_BUILD_TYPE=Debug
         """
+
+        build_type = "Debug" if debug else "Release"
 
         source_dir = Path(source_dir).resolve()
         if build_dir is None:
-            build_dir = source_dir / "_amigo_build"
+            suffix = "_debug" if debug else ""
+            build_dir = source_dir / f"_amigo_build{suffix}"
 
         build_dir = build_dir.resolve()
         build_dir.mkdir(parents=True, exist_ok=True)
@@ -1343,8 +1358,9 @@ amigo_add_python_module(
             f"-DCMAKE_PREFIX_PATH={amigo_cmake_dir}",
             f"-DPython3_EXECUTABLE={sys.executable}",
             f"-Dpybind11_DIR={cmake_pybind11_dir}",
+            f"-DCMAKE_BUILD_TYPE={build_type}",
         ]
-        build_cmd = ["cmake", "--build", str(build_dir), "--config", "Release"]
+        build_cmd = ["cmake", "--build", str(build_dir), "--config", build_type]
 
         print("Running CMake commands from amigo")
         print(" ".join(cmake_cmd))

--- a/amigo/model.py
+++ b/amigo/model.py
@@ -1270,13 +1270,26 @@ class Model:
         debug: bool = False,
     ):
         """
-        Generate the model code and build it. Additional compile, link arguments and macros can be added here.
+        Generate the model code and build it.
 
         Args:
-            debug (bool): Build with debug symbols and no optimization (CMAKE_BUILD_TYPE=Debug).
-                          Useful for getting meaningful stack traces when the module crashes.
-                          The debug .so is placed in a separate _amigo_build_debug directory
-                          so it does not overwrite a Release build.
+            comm: MPI communicator (e.g. ``mpi4py.MPI.COMM_WORLD``). When provided,
+                only rank 0 generates and compiles the C++ module; all ranks then
+                synchronize at a barrier before returning. Pass ``None`` for
+                single-process runs.
+            source_dir (str | Path | None): Directory that contains the amigo
+                C++ source and CMakeLists.txt. If ``None``, the directory is
+                inferred automatically from the current working directory or the
+                location of the calling script.
+            build_dir (str | Path | None): Directory where CMake will write its
+                build artefacts and the compiled ``.so``. If ``None``, a
+                subdirectory named ``_amigo_build`` is created inside
+                ``source_dir``.
+            debug (bool): Build with debug symbols and no optimization
+                (``CMAKE_BUILD_TYPE=Debug``). Useful for getting meaningful stack
+                traces when the module crashes. The debug ``.so`` is placed in a
+                separate ``_amigo_build_debug`` directory so it does not overwrite
+                a Release build.
         """
 
         comm_rank = 0

--- a/amigo/model.py
+++ b/amigo/model.py
@@ -412,6 +412,12 @@ class Model:
             module_name (str): Name of the module that contains the component classes
         """
         self.module_name = module_name
+        if module_name is not None and not module_name.isidentifier():
+            raise ValueError(
+                f"module_name '{module_name}' is not a valid identifier. "
+                f"Use only letters, digits, and underscores, starting with a letter or underscore."
+            )
+        self._built = False
         self.comp = {}
         self.external_comp = {}
         self.index_pool = GlobalIndexPool()
@@ -481,6 +487,60 @@ class Model:
             constraints (List of str): List of strings of the constraint names
         """
 
+        if not isinstance(inputs, list):
+            raise TypeError(
+                f"add_external_component '{name}': inputs must be a list of strings, "
+                f"got {type(inputs).__name__}"
+            )
+        if not isinstance(constraints, list):
+            raise TypeError(
+                f"add_external_component '{name}': constraints must be a list of strings, "
+                f"got {type(constraints).__name__}"
+            )
+        for i, inp in enumerate(inputs):
+            if not isinstance(inp, str):
+                raise TypeError(
+                    f"add_external_component '{name}': inputs[{i}] must be a string, "
+                    f"got {type(inp).__name__!r}"
+                )
+        for i, con in enumerate(constraints):
+            if not isinstance(con, str):
+                raise TypeError(
+                    f"add_external_component '{name}': constraints[{i}] must be a string, "
+                    f"got {type(con).__name__!r}"
+                )
+
+        if not callable(getattr(comp_obj, "evaluate", None)):
+            raise TypeError(
+                f"add_external_component '{name}': comp_obj must have a callable 'evaluate' method"
+            )
+        if not callable(getattr(comp_obj, "get_constraint_jacobian_csr", None)):
+            raise TypeError(
+                f"add_external_component '{name}': comp_obj must have a callable "
+                f"'get_constraint_jacobian_csr' method"
+            )
+
+        # Check: if a constraint listed here is also declared in a registered Python
+        # component, that component must have an empty compute(). If compute() is non-empty,
+        # both the Python side and the external component will write to the same constraint,
+        # causing a segfault in the C++ layer.
+        for con_expr in constraints:
+            parts = con_expr.rsplit(".", 1)
+            if len(parts) == 2:
+                comp_name, con_name = parts
+                if comp_name in self.comp:
+                    py_comp = self.comp[comp_name].comp_obj
+                    if con_name in py_comp.get_constraint_names():
+                        if not py_comp.is_compute_empty():
+                            raise ValueError(
+                                f"add_external_component '{name}': constraint "
+                                f"'{con_expr}' is also declared in Python component "
+                                f"'{comp_name}', which has a non-empty compute(). "
+                                f"The Python component must have an empty compute() when "
+                                f"an external component handles the constraint — otherwise "
+                                f"both will write to the same constraint, causing a segfault."
+                            )
+
         self.external_comp[name] = ExternalComponent(
             name, comp_obj, inputs, constraints
         )
@@ -522,10 +582,10 @@ class Model:
             sub_group = model.external_comp[comp_name]
             sub_obj = sub_group.comp_obj
 
-            for iname in enumerate(sub_group.inputs):
+            for iname in sub_group.inputs:
                 sub_inputs.append(name + "." + iname)
 
-            for iname in enumerate(sub_group.constraints):
+            for iname in sub_group.constraints:
                 sub_constraints.append(name + "." + iname)
 
             self.add_external_component(sub_name, sub_obj, sub_inputs, sub_constraints)
@@ -777,6 +837,12 @@ class Model:
         resulting KKT system is a 2x2 augmented system (eq. 13).
         """
 
+        if self.module_name is not None and not self._built:
+            raise RuntimeError(
+                f"Call model.build_module() before model.initialize(). "
+                f"Module '{self.module_name}' has not been compiled in this session."
+            )
+
         self.num_variables = self._init_indices(
             self.links, self.index_pool, vtype="vars"
         )
@@ -867,17 +933,36 @@ class Model:
         comp_name = ".".join(path[:-1])
         var_name = path[-1]
 
-        if var_name in self.comp[comp_name].get_input_names():
+        if comp_name not in self.comp:
+            registered = list(self.comp.keys())
+            hints = [c for c in registered if c.startswith(comp_name + ".") or c.endswith("." + comp_name)]
+            msg = (
+                f"Component '{comp_name}' not found when resolving '{name}'. "
+                f"Registered components: {registered}"
+            )
+            if hints:
+                msg += f". Did you mean one of: {hints}?"
+            raise ValueError(msg)
+
+        group = self.comp[comp_name]
+        if var_name in group.get_input_names():
             return "input"
-        elif var_name in self.comp[comp_name].get_constraint_names():
+        elif var_name in group.get_constraint_names():
             return "constraint"
-        elif var_name in self.comp[comp_name].get_data_names():
+        elif var_name in group.get_data_names():
             return "data"
-        elif var_name in self.comp[comp_name].get_output_names():
+        elif var_name in group.get_output_names():
             return "output"
         else:
+            available = (
+                list(group.get_input_names())
+                + list(group.get_constraint_names())
+                + list(group.get_data_names())
+                + list(group.get_output_names())
+            )
             raise ValueError(
-                f"Name {comp_name}.{var_name} is neither an input, constraint, output or data"
+                f"'{var_name}' not found in component '{comp_name}'. "
+                f"Available variables: {available}"
             )
 
     def get_indices(self, name: str | List[str]):
@@ -1225,6 +1310,7 @@ class Model:
         if comm is not None:
             comm.Barrier()
 
+        self._built = True
         return
 
     def generate_cpp(self):

--- a/amigo/model.py
+++ b/amigo/model.py
@@ -455,6 +455,11 @@ class Model:
         if name in self.comp:
             raise ValueError(f"Cannot add two components with the same name")
 
+        if not callable(getattr(comp_obj, "compute", None)):
+            raise TypeError(
+                f"add_component '{name}': comp_obj must have a callable 'compute' method"
+            )
+
         vs = comp_obj.get_var_shapes()
         var_shapes = self._get_group_shapes(size, vs)
         ds = comp_obj.get_data_shapes()

--- a/build_debug.sh
+++ b/build_debug.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Build amigo in debug mode and install to the active Python environment.
+# Run once (or after C++ source changes). Subsequent runs are incremental.
+#
+# Usage: ./scripts/build_debug.sh
+
+set -euo pipefail
+
+AMIGO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$AMIGO_DIR/_build_debug"
+
+# Resolve the installed .so path from the active Python environment
+INSTALL_DIR=$(python -c "import amigo.amigo, os; print(os.path.dirname(amigo.amigo.__file__))")
+SO_NAME=$(python -c "import amigo.amigo, os; print(os.path.basename(amigo.amigo.__file__))")
+
+echo "==> Configuring debug build in $BUILD_DIR"
+cmake -S "$AMIGO_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Debug
+
+echo "==> Building"
+cmake --build "$BUILD_DIR" --parallel
+
+echo "==> Generating dSYM"
+dsymutil "$BUILD_DIR/$SO_NAME"
+
+echo "==> Installing to $INSTALL_DIR"
+cp "$BUILD_DIR/$SO_NAME" "$INSTALL_DIR/"
+cp -r "$BUILD_DIR/$SO_NAME.dSYM" "$INSTALL_DIR/"
+
+echo "==> Done. Debug amigo installed to $INSTALL_DIR"
+echo "    Run your script under lldb with:"
+echo "      lldb python -- your_script.py"

--- a/build_debug.sh
+++ b/build_debug.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-AMIGO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AMIGO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="$AMIGO_DIR/_build_debug"
 
 # Resolve the installed .so path from the active Python environment

--- a/examples/interp/smt/smt_quadratic.py
+++ b/examples/interp/smt/smt_quadratic.py
@@ -1,0 +1,120 @@
+"""Minimal ExternalSMTComponent verification example.
+
+Problem: minimize x  subject to  KRG(x) = y,  y >= 0.25
+where KRG is trained on y = x^2 over x in [0, 2].
+
+Known answer: x* = 0.5, y* = 0.25  (active lower bound on y)
+
+This example isolates ExternalSMTComponent from application complexity
+to verify that the surrogate constraint is wired and evaluated correctly.
+"""
+
+import amigo as am
+import numpy as np
+from smt.surrogate_models import KRG
+from amigo.interp import ExternalSMTComponent
+
+# ── Train a 1-input KRG surrogate on y = x² ──────────────────────────────────
+x_train = np.linspace(0.0, 2.0, 20).reshape(-1, 1)
+y_train = x_train**2
+
+sm = KRG(theta0=[1e-2], print_global=False)
+sm.set_training_values(x_train, y_train)
+sm.train()
+
+# Sanity check: surrogate should predict ≈ 0.25 at x = 0.5
+pred = sm.predict_values(np.array([[0.5]]))
+print(f"Surrogate check: KRG(0.5) = {pred[0,0]:.6f}  (expect ~0.25)")
+
+# ── ExternalSMTComponent ──────────────────────────────────────────────────────
+# num_points=1, num_inputs=1: the x-vector layout inside evaluate() is
+#   x[0:1] = surrogate input (src.x)
+#   x[1:2] = surrogate output (src.y)
+# and the constraint enforced is:  KRG(x[0]) - x[1] = 0
+smt_ext = ExternalSMTComponent(num_points=1, num_inputs=1, smt_model=sm)
+
+
+# ── Amigo components ──────────────────────────────────────────────────────────
+class Source(am.Component):
+    """Holds the design variable x and the surrogate output y."""
+    def __init__(self):
+        super().__init__()
+        self.add_input("x")
+        self.add_input("y")
+
+
+class SMTConstraintPlaceholder(am.Component):
+    """Declares the surrogate residual constraint without a compute() override.
+
+    No compute() method means is_compute_empty() returns True, so Amigo
+    generates no C++ group for this component.  The ExternalSMTComponent is
+    the sole writer of 'res', avoiding a double-write segfault.
+    """
+    def __init__(self):
+        super().__init__()
+        self.add_constraint("res")
+
+
+class Objective(am.Component):
+    """Minimize x."""
+    def __init__(self):
+        super().__init__()
+        self.add_input("x")
+        self.add_objective("obj")
+
+    def compute(self):
+        self.objective["obj"] = self.inputs["x"]
+
+
+# ── Assemble model ────────────────────────────────────────────────────────────
+model = am.Model("smt_quadratic")
+model.add_component("src", 1, Source())
+model.add_component("smt_con", 1, SMTConstraintPlaceholder())
+model.add_component("obj", 1, Objective())
+model.link("src.x", "obj.x")
+
+# The inputs list must match ExternalSMTComponent's x-vector layout:
+#   first num_inputs*num_points entries  → surrogate inputs (column-major by input)
+#   last  num_points entries             → surrogate outputs
+model.add_external_component(
+    "smt",
+    smt_ext,
+    inputs=["src.x", "src.y"],
+    constraints=["smt_con.res"],
+)
+
+model.build_module()
+model.initialize()
+
+print(f"Num variables:   {model.num_variables}")
+print(f"Num constraints: {model.num_constraints}")
+
+# ── Initial guess ─────────────────────────────────────────────────────────────
+xvec = model.create_vector()
+lower = model.create_vector()
+upper = model.create_vector()
+
+xvec["src.x"] = 1.0
+xvec["src.y"] = float(sm.predict_values(np.array([[1.0]]))[0, 0])  # on surrogate → res ≈ 0
+
+lower["src.x"] = 0.0
+upper["src.x"] = 2.0
+lower["src.y"] = 0.25   # y >= 0.25  drives x >= 0.5 via the surrogate constraint
+upper["src.y"] = float("inf")
+
+# ── Optimize ──────────────────────────────────────────────────────────────────
+opt = am.Optimizer(model, xvec, lower=lower, upper=upper)
+opt.optimize({
+    "max_iterations": 200,
+    "initial_barrier_param": 1.0,
+    "convergence_tolerance": 1e-10,
+    "max_line_search_iterations": 10,
+    "init_affine_step_multipliers": False,
+    "init_least_squares_multipliers": False,
+})
+
+x_opt = xvec["src.x"][0]
+y_opt = xvec["src.y"][0]
+print(f"\nResult:  x = {x_opt:.6f}  (expect 0.5)")
+print(f"         y = {y_opt:.6f}  (expect 0.25)")
+print(f"  KRG(x*) = {sm.predict_values(np.array([[x_opt]]))[0,0]:.6f}  (expect ~0.25)")

--- a/examples/interp/smt/smt_quadratic.py
+++ b/examples/interp/smt/smt_quadratic.py
@@ -37,6 +37,7 @@ smt_ext = ExternalSMTComponent(num_points=1, num_inputs=1, smt_model=sm)
 # ── Amigo components ──────────────────────────────────────────────────────────
 class Source(am.Component):
     """Holds the design variable x and the surrogate output y."""
+
     def __init__(self):
         super().__init__()
         self.add_input("x")
@@ -50,6 +51,7 @@ class SMTConstraintPlaceholder(am.Component):
     generates no C++ group for this component.  The ExternalSMTComponent is
     the sole writer of 'res'.
     """
+
     def __init__(self):
         super().__init__()
         self.add_constraint("res")
@@ -57,6 +59,7 @@ class SMTConstraintPlaceholder(am.Component):
 
 class Objective(am.Component):
     """Minimize x."""
+
     def __init__(self):
         super().__init__()
         self.add_input("x")
@@ -95,23 +98,27 @@ lower = model.create_vector()
 upper = model.create_vector()
 
 xvec["src.x"] = 1.0
-xvec["src.y"] = float(sm.predict_values(np.array([[1.0]]))[0, 0])  # on surrogate → res ≈ 0
+xvec["src.y"] = float(
+    sm.predict_values(np.array([[1.0]]))[0, 0]
+)  # on surrogate → res ≈ 0
 
 lower["src.x"] = 0.0
 upper["src.x"] = 2.0
-lower["src.y"] = 0.25   # y >= 0.25  drives x >= 0.5 via the surrogate constraint
+lower["src.y"] = 0.25  # y >= 0.25  drives x >= 0.5 via the surrogate constraint
 upper["src.y"] = float("inf")
 
 # ── Optimize ──────────────────────────────────────────────────────────────────
 opt = am.Optimizer(model, xvec, lower=lower, upper=upper)
-opt.optimize({
-    "max_iterations": 200,
-    "initial_barrier_param": 1.0,
-    "convergence_tolerance": 1e-10,
-    "max_line_search_iterations": 10,
-    "init_affine_step_multipliers": False,
-    "init_least_squares_multipliers": False,
-})
+opt.optimize(
+    {
+        "max_iterations": 200,
+        "initial_barrier_param": 1.0,
+        "convergence_tolerance": 1e-10,
+        "max_line_search_iterations": 10,
+        "init_affine_step_multipliers": False,
+        "init_least_squares_multipliers": False,
+    }
+)
 
 x_opt = xvec["src.x"][0]
 y_opt = xvec["src.y"][0]

--- a/examples/interp/smt/smt_quadratic.py
+++ b/examples/interp/smt/smt_quadratic.py
@@ -48,7 +48,7 @@ class SMTConstraintPlaceholder(am.Component):
 
     No compute() method means is_compute_empty() returns True, so Amigo
     generates no C++ group for this component.  The ExternalSMTComponent is
-    the sole writer of 'res', avoiding a double-write segfault.
+    the sole writer of 'res'.
     """
     def __init__(self):
         super().__init__()

--- a/include/ordering_utils.h
+++ b/include/ordering_utils.h
@@ -776,7 +776,7 @@ class OrderingUtils {
       }
 
       // Add the result from the transpose
-      for (int i = 0; i < nvars; i++) {
+      for (int i = 0; i < ncons; i++) {
         for (int jp = jac_rowp[i]; jp < jac_rowp[i + 1]; jp++) {
           int j = jac_cols[jp];
           int col = vars[j];

--- a/scripts/build_debug.sh
+++ b/scripts/build_debug.sh
@@ -2,11 +2,20 @@
 # Build amigo in debug mode and install to the active Python environment.
 # Run once (or after C++ source changes). Subsequent runs are incremental.
 #
-# Usage: ./scripts/build_debug.sh
+# Usage: ./build_debug.sh
+#
+# Cross-platform alternative (macOS / Linux / Windows):
+#   Debug:    pip install -e . -Ccmake.build-type=Debug -Ccmake.build-dir=_build_debug
+#   Release:  pip install -e .
+#
+# Note: the pip approach overwrites whichever build is currently installed,
+# so only one build type is active at a time. This script keeps a separate
+# _build_debug directory and copies the result into the active environment,
+# which is macOS-only (requires dsymutil).
 
 set -euo pipefail
 
-AMIGO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AMIGO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}"/..)" && pwd)"
 BUILD_DIR="$AMIGO_DIR/_build_debug"
 
 # Resolve the installed .so path from the active Python environment

--- a/tests/interp/test_smt_quadratic.py
+++ b/tests/interp/test_smt_quadratic.py
@@ -1,0 +1,139 @@
+"""pytest for the ExternalSMTComponent example.
+
+Verifies that a 1-input KRG surrogate is correctly wired into an Amigo
+model via ExternalSMTComponent, and that the optimizer recovers the known
+solution x* = 0.5, y* = 0.25 for:
+
+    minimize  x
+    subject to  KRG(x) = y   (surrogate equality constraint)
+                y >= 0.25    (bound drives x to 0.5)
+                x in [0, 2]
+
+Run with:
+    pytest test_smt_quadratic.py -v
+"""
+
+import numpy as np
+import pytest
+
+import amigo as am
+from amigo.interp import ExternalSMTComponent
+from smt.surrogate_models import KRG
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def trained_krg():
+    """KRG surrogate trained on y = x^2 over [0, 2]."""
+    x_train = np.linspace(0.0, 2.0, 20).reshape(-1, 1)
+    y_train = x_train**2
+    sm = KRG(theta0=[1e-2], print_global=False)
+    sm.set_training_values(x_train, y_train)
+    sm.train()
+    return sm
+
+
+@pytest.fixture(scope="module")
+def opt_result(trained_krg):
+    """Build and solve the model once; return (xvec, model)."""
+    sm = trained_krg
+    smt_ext = ExternalSMTComponent(num_points=1, num_inputs=1, smt_model=sm)
+
+    class Source(am.Component):
+        def __init__(self):
+            super().__init__()
+            self.add_input("x")
+            self.add_input("y")
+
+    class SMTConstraintPlaceholder(am.Component):
+        def __init__(self):
+            super().__init__()
+            self.add_constraint("res")
+
+    class Objective(am.Component):
+        def __init__(self):
+            super().__init__()
+            self.add_input("x")
+            self.add_objective("obj")
+
+        def compute(self):
+            self.objective["obj"] = self.inputs["x"]
+
+    model = am.Model("smt_quadratic_test")
+    model.add_component("src", 1, Source())
+    model.add_component("smt_con", 1, SMTConstraintPlaceholder())
+    model.add_component("obj", 1, Objective())
+    model.link("src.x", "obj.x")
+    model.add_external_component(
+        "smt",
+        smt_ext,
+        inputs=["src.x", "src.y"],
+        constraints=["smt_con.res"],
+    )
+    model.build_module()
+    model.initialize()
+
+    xvec = model.create_vector()
+    lower = model.create_vector()
+    upper = model.create_vector()
+
+    xvec["src.x"] = 1.0
+    xvec["src.y"] = float(sm.predict_values(np.array([[1.0]]))[0, 0])
+
+    lower["src.x"] = 0.0
+    upper["src.x"] = 2.0
+    lower["src.y"] = 0.25
+    upper["src.y"] = float("inf")
+
+    opt = am.Optimizer(model, xvec, lower=lower, upper=upper)
+    data = opt.optimize({
+        "max_iterations": 200,
+        "initial_barrier_param": 1.0,
+        "convergence_tolerance": 1e-10,
+        "max_line_search_iterations": 10,
+        "init_affine_step_multipliers": False,
+        "init_least_squares_multipliers": False,
+    })
+    return xvec, data
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_surrogate_accuracy(trained_krg):
+    """KRG should interpolate y = x^2 to machine precision at training points."""
+    sm = trained_krg
+    x_check = np.array([[0.0], [0.5], [1.0], [1.5], [2.0]])
+    pred = sm.predict_values(x_check).flatten()
+    expected = x_check.flatten()**2
+    np.testing.assert_allclose(pred, expected, atol=1e-6)
+
+
+def test_converged(opt_result):
+    """Optimizer must report convergence."""
+    _, data = opt_result
+    assert data["converged"], "Optimizer did not converge"
+
+
+def test_optimal_x(opt_result):
+    """Optimal x should be 0.5 (active lower bound y=0.25 via KRG(x)=x^2)."""
+    xvec, _ = opt_result
+    x_opt = xvec["src.x"][0]
+    assert abs(x_opt - 0.5) < 1e-4, f"x* = {x_opt:.6f}, expected 0.5"
+
+
+def test_optimal_y(opt_result):
+    """Optimal y should be 0.25 (active lower bound)."""
+    xvec, _ = opt_result
+    y_opt = xvec["src.y"][0]
+    assert abs(y_opt - 0.25) < 1e-4, f"y* = {y_opt:.6f}, expected 0.25"
+
+
+def test_surrogate_constraint_satisfied(opt_result, trained_krg):
+    """Surrogate residual KRG(x*) - y* must be near zero at the solution."""
+    xvec, _ = opt_result
+    x_opt = xvec["src.x"][0]
+    y_opt = xvec["src.y"][0]
+    pred = trained_krg.predict_values(np.array([[x_opt]]))[0, 0]
+    residual = abs(pred - y_opt)
+    assert residual < 1e-6, f"Surrogate residual = {residual:.2e}, expected < 1e-6"

--- a/tests/interp/test_smt_quadratic.py
+++ b/tests/interp/test_smt_quadratic.py
@@ -23,6 +23,7 @@ from smt.surrogate_models import KRG
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
+
 @pytest.fixture(scope="module")
 def trained_krg():
     """KRG surrogate trained on y = x^2 over [0, 2]."""
@@ -87,25 +88,28 @@ def opt_result(trained_krg):
     upper["src.y"] = float("inf")
 
     opt = am.Optimizer(model, xvec, lower=lower, upper=upper)
-    data = opt.optimize({
-        "max_iterations": 200,
-        "initial_barrier_param": 1.0,
-        "convergence_tolerance": 1e-10,
-        "max_line_search_iterations": 10,
-        "init_affine_step_multipliers": False,
-        "init_least_squares_multipliers": False,
-    })
+    data = opt.optimize(
+        {
+            "max_iterations": 200,
+            "initial_barrier_param": 1.0,
+            "convergence_tolerance": 1e-10,
+            "max_line_search_iterations": 10,
+            "init_affine_step_multipliers": False,
+            "init_least_squares_multipliers": False,
+        }
+    )
     return xvec, data
 
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
+
 
 def test_surrogate_accuracy(trained_krg):
     """KRG should interpolate y = x^2 to machine precision at training points."""
     sm = trained_krg
     x_check = np.array([[0.0], [0.5], [1.0], [1.5], [2.0]])
     pred = sm.predict_values(x_check).flatten()
-    expected = x_check.flatten()**2
+    expected = x_check.flatten() ** 2
     np.testing.assert_allclose(pred, expected, atol=1e-6)
 
 


### PR DESCRIPTION
# Summary
Revamp build procedure to add multiple configuration modes. Also include a bash script to build in debug mode and copy *.dSYM to install directory so that a debugger can read symbol names. Input validation and improved error handling has been introduced to the `model` and `ExternalSMTComponent`.

Several bug fixes related to SMT interface and ordering_utils are included.

## Build System
Added functionality to the CMake system that now supports different build types: `Release`, `Debug`, and `RelWithDebInfo`. These build types set relevant compiler flags for optimization and debugging symbols. 

- **NOTE:** `scikit-build-core` strips debug info during pip install, so it is necessary to directly call `cmake` to build and then manually copy the `.dSYM` bundle to the install directory (this is handled by the new `build_debug.sh` script). This affects the core Amigo module installation. 
 
To enable debugging info for a particular problem, a `debug` parameter was added to `build_module()` which handles the build type for compiling the _problem module_. So to fully debug something with a useful backtrace, one would run `build_debug.sh` to install the debug version of Amigo. Then, in the problem script, add `debug = True` to `.build_module()`. After this, symbolic debugging information should be available in `gdb` or `lldb`.

**NOTE:** You shouldn't _need_ the bash script, it is just there as an example and a method that _should_ routinely work on macOS. The `build_debug.sh` contains info in its header comments about installing in debug mode using `pip install`.

## Input Validation
- Check SMT model API compatibility and valid `num_points`, `num_inputs` parameters
- Check module names are valid early in `Model.__init__` before doing any work
- `add_external_component`: validates `inputs` and `constraints` are lists of strings, `comp_obj` has `evaluate` and `get_constraint_jacobian_csr` methods.

## Fixed Bugs
- Typo in `ordering_utils.h` would potentially lead to segfault for an external component with $nvars \ne ncons$
- The recent update to handling `fixed_vars` in the model breaks if `fixed_vars` is an empty array. 
- The arrays from `smt.predict_values` and `smt.predict_derivatives` did not match the expected array shapes; these needed to be flattened.
- In `model.py`: `add_model` featured for loops with `enumerate` which yields (int, str) tuples. These should just be plain for loops. This would cause errors when trying to add a sub-model that has external components.

## Unit Testing
Started a new /tests/ folder for unit tests and added a test for SMT based on solving a quadratic problem. Tests in this folder will now automatically be run on macOS, Linux, and Windows by GitHub for PRs.

## Work in Progress
- Perhaps switch to a `_built` flag in model, still working on making this work automatically with precompiled builds. Right now it just does a warning.