### PR TITLE
Add diagnostics for model setup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,15 +12,6 @@ on:
       - 'amigo/**'
       - 'include/**'
       - '.github/workflows/docker.yml'
-  pull_request:
-    paths:
-      - 'Dockerfile'
-      - '.dockerignore'
-      - 'pyproject.toml'
-      - 'CMakeLists.txt'
-      - 'amigo/**'
-      - 'include/**'
-      - '.github/workflows/docker.yml'
   workflow_dispatch:
 
 # Allow only one concurrent docker build per ref; cancel older runs.

--- a/.github/workflows/pytest-linux.yml
+++ b/.github/workflows/pytest-linux.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/pytest-linux.yml
+++ b/.github/workflows/pytest-linux.yml
@@ -1,4 +1,4 @@
-name: pytest
+name: pytest (Linux)
 
 on:
   push:
@@ -7,7 +7,6 @@ on:
 
 jobs:
   test:
-    # Windows/macOS excluded: ThirdParty-Mumps build requires Fortran toolchain
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +29,7 @@ jobs:
           ./configure --prefix=$HOME/mumps-coinor
           make -j$(nproc)
           make install
+          echo "MUMPS_LIB_DIR=$HOME/mumps-coinor/lib" >> $GITHUB_ENV
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install amigo
         env:
-          MUMPS_LIB_DIR: /home/runner/mumps-coinor/lib
+          MUMPS_LIB_DIR: ${{ env.MUMPS_LIB_DIR }}
         run: |
           pip install scikit-build-core pybind11 mpi4py numpy scipy matplotlib
           pip install -e .
@@ -48,6 +48,5 @@ jobs:
 
       - name: Run tests
         env:
-          MUMPS_LIB_DIR: /home/runner/mumps-coinor/lib
-          LD_LIBRARY_PATH: /home/runner/mumps-coinor/lib
+          LD_LIBRARY_PATH: ${{ env.MUMPS_LIB_DIR }}
         run: pytest tests/ -v

--- a/.github/workflows/pytest-macos.yml
+++ b/.github/workflows/pytest-macos.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/pytest-macos.yml
+++ b/.github/workflows/pytest-macos.yml
@@ -1,0 +1,56 @@
+name: pytest (macOS)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout amigo
+        uses: actions/checkout@v4
+
+      - name: Install Homebrew dependencies
+        run: |
+          brew install cmake gcc open-mpi openblas
+          echo "/opt/homebrew/bin" >> $GITHUB_PATH
+          echo "/usr/local/bin" >> $GITHUB_PATH
+          GFC=$(find /opt/homebrew/bin /usr/local/bin -name 'gfortran-*' 2>/dev/null | head -1)
+          sudo ln -sf "$GFC" /usr/local/bin/gfortran
+          gfortran --version
+
+      - name: Build ThirdParty-Mumps
+        run: |
+          git clone --depth 1 https://github.com/coin-or-tools/ThirdParty-Mumps.git ~/ThirdParty-Mumps
+          cd ~/ThirdParty-Mumps
+          ./get.Mumps
+          ./configure --prefix=$HOME/mumps-coinor FC=/usr/local/bin/gfortran F77=/usr/local/bin/gfortran
+          make -j$(sysctl -n hw.ncpu)
+          make install
+          echo "MUMPS_LIB_DIR=$HOME/mumps-coinor/lib" >> $GITHUB_ENV
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Checkout a2d
+        run: git clone --depth 1 https://github.com/smdogroup/a2d.git ../a2d
+
+      - name: Install amigo
+        env:
+          MUMPS_LIB_DIR: ${{ env.MUMPS_LIB_DIR }}
+        run: |
+          pip install scikit-build-core pybind11 mpi4py numpy scipy matplotlib
+          pip install -e .
+
+      - name: Install test dependencies
+        run: pip install pytest smt
+
+      - name: Run tests
+        env:
+          DYLD_LIBRARY_PATH: ${{ env.MUMPS_LIB_DIR }}
+        run: pytest tests/ -v

--- a/.github/workflows/pytest-windows.yml
+++ b/.github/workflows/pytest-windows.yml
@@ -13,10 +13,18 @@ jobs:
       - name: Checkout amigo
         uses: actions/checkout@v4
 
+      - name: Install system dependencies
+        uses: mpi4py/setup-mpi@v1
+        with:
+          mpi: msmpi
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Install BLAS
+        pip install mkl mkl-devel
 
       - name: Checkout a2d
         run: git clone --depth 1 https://github.com/smdogroup/a2d.git ../a2d

--- a/.github/workflows/pytest-windows.yml
+++ b/.github/workflows/pytest-windows.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install BLAS
-        pip install mkl mkl-devel
+        run: pip install mkl mkl-devel
 
       - name: Checkout a2d
         run: git clone --depth 1 https://github.com/smdogroup/a2d.git ../a2d

--- a/.github/workflows/pytest-windows.yml
+++ b/.github/workflows/pytest-windows.yml
@@ -1,9 +1,10 @@
 name: pytest (Windows)
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  #push:
+  #  branches: [main]
+  #pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/pytest-windows.yml
+++ b/.github/workflows/pytest-windows.yml
@@ -1,0 +1,39 @@
+name: pytest (Windows)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout amigo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Checkout a2d
+        run: git clone --depth 1 https://github.com/smdogroup/a2d.git ../a2d
+
+      - name: Install amigo
+        # MUMPS_LIB_DIR is intentionally not set: amigo is built without Mumps support
+        # because the Fortran toolchain required to build ThirdParty-Mumps is not
+        # available on Windows runners.
+        run: |
+          pip install scikit-build-core pybind11 mpi4py numpy scipy matplotlib
+          pip install -e .
+
+      - name: Install test dependencies
+        run: pip install pytest smt
+
+      - name: Run tests
+        # tests/interp is excluded because it contains Mumps-dependent tests that
+        # require the ThirdParty-Mumps library, which cannot be built on Windows
+        # runners due to the absence of a Fortran toolchain (gfortran).
+        run: pytest tests/ -v --ignore=tests/interp

--- a/amigo/__init__.py
+++ b/amigo/__init__.py
@@ -33,6 +33,7 @@ from .amigo import (
 )
 from .component import Component
 from .model import Model
+from .diagnostics import Diagnostics
 from .optimizer import *
 from .utils import *
 from .unary_operations import *

--- a/amigo/diagnostics.py
+++ b/amigo/diagnostics.py
@@ -1,7 +1,7 @@
 """
 amigo.diagnostics
 =================
-General-purpose pre-optimisation diagnostic checks for any Amigo model.
+General-purpose pre-optimization diagnostic checks for any Amigo model.
 
 Usage
 -----
@@ -58,12 +58,12 @@ def _strip_indices(expr: str) -> str:
 
 
 class Diagnostics:
-    """Pre-optimisation health checks for an initialised Amigo model.
+    """Pre-optimization health checks for an initialized Amigo model.
 
     Parameters
     ----------
     model:
-        An initialised ``am.Model`` instance.
+        An initialized ``am.Model`` instance.
     x:
         Design vector returned by ``model.create_vector()`` and populated
         with the initial guess.

--- a/amigo/diagnostics.py
+++ b/amigo/diagnostics.py
@@ -74,6 +74,7 @@ class Diagnostics:
 
     _TOL_BOUND: float = 1e-10
     _MAX_VIOLATIONS_SHOWN: int = 5
+    _MAX_INFEASIBILITY = 1.0
 
     def __init__(self, model, x, lower=None, upper=None):
         self.model = model
@@ -429,17 +430,17 @@ class Diagnostics:
             max_r = float(np.max(np.abs(arr)))
             mean_r = float(np.mean(np.abs(arr)))
             all_max.append(max_r)
-            flag = "  [!!]" if max_r > 1.0 else "      "
+            flag = "  [!!]" if max_r > self._MAX_INFEASIBILITY else "      "
             print(f"  {flag}  {name:38s}  max={max_r:.4e}  mean={mean_r:.4e}")
 
         if all_max:
             inf_pr = max(all_max)
-            tag = "[WARN]" if inf_pr > 1.0 else "[OK]  "
+            tag = "[WARN]" if inf_pr > self._MAX_INFEASIBILITY else "[OK]  "
             print(
                 f"\n      {tag} inf_pr estimate = {inf_pr:.4e}"
                 f"  (should match optimizer iter-0 inf_pr)"
             )
-            if inf_pr > 1.0:
+            if inf_pr > self._MAX_INFEASIBILITY:
                 fail = True
 
         return fail

--- a/amigo/diagnostics.py
+++ b/amigo/diagnostics.py
@@ -27,7 +27,7 @@ The five checks
    components but whose global indices don't overlap are likely missing a
    ``model.link()`` call.
 4. **Constraint residuals** - evaluate all constraints using
-   ``model.eval_constraints(x)`` and report ``max|res|`` / ``mean|res|`` for
+   ``self._eval_constraints(x)`` and report ``max|res|`` / ``mean|res|`` for
    each group.  The largest value is an estimate of ``inf_pr`` at iter 0.
 5. **Spotlight constraints** - read named constraint-residual variables
    directly from ``x`` (useful for IC/FC whose values the user seeds during
@@ -143,6 +143,51 @@ class Diagnostics:
         }
 
         return total_fail, fail_dict
+
+    def _eval_constraints(self, x: ModelVector) -> dict:
+        """Evaluate all constraint functions at x without running the optimizer.
+
+        Uses the gradient infrastructure: with alpha=0, the gradient vector g
+        is zeroed at primal positions (no objective contribution), and entries
+        at the multiplier positions contain c(x) for every equality constraint.
+        This follows the KKT structure where g[mult] = c(x).
+
+        Returns
+        -------
+        dict
+            Maps each constraint group name (e.g. ``"ac.res"``, ``"trap.res"``)
+            to a numpy array of residual values evaluated at x.
+
+        Raises
+        ------
+        RuntimeError
+            If the total size of named constraint groups does not match the
+            number of multiplier variables, indicating an ordering mismatch.
+        """
+        g = self.model.create_vector()
+        self.model.eval_gradient(x, g, alpha=0.0)
+        g_arr = np.asarray(g[:], dtype=float)
+
+        mult_mask = np.asarray(
+            self.model.problem.get_multiplier_indicator(), dtype=bool
+        )
+        c_flat = g_arr[mult_mask]
+
+        result = {}
+        k = 0
+        _, cons_names, _, _ = self.model.get_names()
+        for name in cons_names:
+            n = int(np.atleast_1d(self.model.get_indices(name)).size)
+            result[name] = c_flat[k : k + n]
+            k += n
+
+        if k != len(c_flat):
+            raise RuntimeError(
+                f"eval_constraints: named constraints sum to {k} entries "
+                f"but multiplier vector has {len(c_flat)}. "
+                "Constraint ordering mismatch — please report this as a bug."
+            )
+        return result
 
     # ── check 1: NaN / Inf ────────────────────────────────────────────────────
 
@@ -364,13 +409,13 @@ class Diagnostics:
 
         return fail
 
-    # ── check 4: constraint residuals via model.eval_constraints ─────────────
+    # ── check 4: constraint residuals via _eval_constraints ─────────────
 
     def _check_constraints(self) -> bool:
         fail = False
-        print("\n  [4] Constraint residuals (model.eval_constraints)")
+        print("\n  [4] Constraint residuals")
         try:
-            residuals = self.model.eval_constraints(self.x)
+            residuals = self._eval_constraints(self.x)
         except Exception as exc:
             print(f"      [ERR]  eval_constraints failed: {exc}")
             fail = True

--- a/amigo/diagnostics.py
+++ b/amigo/diagnostics.py
@@ -10,7 +10,7 @@ Usage
     import amigo as am
 
     diag = am.Diagnostics(model, x, lower, upper)
-    diag.run(
+    failed, details = diag.run(
         spotlights={
             "ic.res": ["velocity", "gamma", "altitude", "range", "mass"],
             "fc.res": ["velocity", "gamma", "altitude"],
@@ -101,6 +101,15 @@ class Diagnostics:
             IC/FC targets) as part of the initial guess.
         tol:
             Residual tolerance used for pass/fail in spotlight check.
+
+        Returns
+        -------
+        failed : bool
+            ``True`` if any check failed, ``False`` if every check passed.
+        details : dict[str, bool]
+            Per-check failure flags.  Keys: ``"nan_inf"``, ``"bounds"``,
+            ``"connectivity"``, ``"constraints"``, ``"spotlights"``.
+            Each value is ``True`` if that check failed, ``False`` if it passed.
         """
         spotlights = spotlights or {}
 

--- a/amigo/diagnostics.py
+++ b/amigo/diagnostics.py
@@ -11,10 +11,6 @@ Usage
 
     diag = am.Diagnostics(model, x, lower, upper)
     diag.run(
-        evaluators={
-            "ac.res":   lambda x: compute_dynamics(x),   # returns np.ndarray
-            "trap.res": lambda x: compute_trap(x),
-        },
         spotlights={
             "ic.res": ["velocity", "gamma", "altitude", "range", "mass"],
             "fc.res": ["velocity", "gamma", "altitude"],
@@ -30,8 +26,8 @@ The five checks
 3. **Connectivity** - variables sharing the same short name across different
    components but whose global indices don't overlap are likely missing a
    ``model.link()`` call.
-4. **Constraint residuals** - evaluate user-supplied Python callables
-   (one per constraint group) and report ``max|res|`` / ``mean|res|`` for
+4. **Constraint residuals** - evaluate all constraints using
+   ``model.eval_constraints(x)`` and report ``max|res|`` / ``mean|res|`` for
    each group.  The largest value is an estimate of ``inf_pr`` at iter 0.
 5. **Spotlight constraints** - read named constraint-residual variables
    directly from ``x`` (useful for IC/FC whose values the user seeds during
@@ -90,26 +86,22 @@ class Diagnostics:
 
     def run(
         self,
-        evaluators: dict | None = None,
         spotlights: dict | None = None,
         tol: float = 1e-6,
-    ) -> None:
+    ):
         """Run all five checks and print a formatted report.
 
         Parameters
         ----------
-        evaluators:
-            ``{constraint_group_name: callable(x) -> array-like}``
-            The callable receives the ``ModelVector`` and must return the
-            constraint residuals for that group as a flat or shaped array.
         spotlights:
             ``{constraint_var_name: [label_0, label_1, ...]}``.
             Each named constraint variable is read directly from ``x`` and
-            its per-element value is printed with a pass/fail tag.
+            its per-element value is printed with a pass/fail tag.  Useful
+            when the user explicitly seeds constraint residual variables (e.g.
+            IC/FC targets) as part of the initial guess.
         tol:
             Residual tolerance used for pass/fail in spotlight check.
         """
-        evaluators = evaluators or {}
         spotlights = spotlights or {}
 
         nvar = self.model.num_variables
@@ -121,32 +113,51 @@ class Diagnostics:
         print(f"  Model: {mname!r}   Variables: {nvar}   Constraints: {ncon}")
         print(_SEP)
 
-        self._check_nan_inf()
-        self._check_bounds()
-        self._check_connectivity()
-        self._check_evaluators(evaluators)
-        self._check_spotlights(spotlights, tol)
+        nan_fail = self._check_nan_inf()
+        bounds_fail = self._check_bounds()
+        connect_fail = self._check_connectivity()
+        constrain_fail = self._check_constraints()
+        spot_fail = self._check_spotlights(spotlights, tol)
 
         print(f"{_SEP}\n")
 
+        total_fail = (
+            nan_fail or bounds_fail or connect_fail or constrain_fail or spot_fail
+        )
+
+        fail_dict = {
+            "nan_inf": nan_fail,
+            "bounds": bounds_fail,
+            "connectivity": connect_fail,
+            "constraints": constrain_fail,
+            "spotlights": spot_fail,
+        }
+
+        return total_fail, fail_dict
+
     # ── check 1: NaN / Inf ────────────────────────────────────────────────────
 
-    def _check_nan_inf(self) -> None:
+    def _check_nan_inf(self) -> bool:
+        fail = True
         print("\n  [1] NaN / Inf in design vector")
         x_arr = np.asarray(self.x[:], dtype=float)
         bad = ~np.isfinite(x_arr)
         n_bad = int(bad.sum())
         if n_bad == 0:
             print(f"      [OK]   No NaN/Inf ({x_arr.size} entries checked)")
+            fail = False
         else:
             print(f"      [FAIL] {n_bad} non-finite entries")
             for idx in np.where(bad)[0][: self._MAX_VIOLATIONS_SHOWN]:
                 name = self._idx_to_name.get(int(idx), f"idx={idx}")
                 print(f"             {name:40s}  val={x_arr[idx]}")
 
+        return fail
+
     # ── check 2: bounds ───────────────────────────────────────────────────────
 
-    def _check_bounds(self) -> None:
+    def _check_bounds(self) -> bool:
+        fail = False
         print("\n  [2] Bounds analysis")
 
         x_arr = np.asarray(self.x[:], dtype=float)
@@ -164,6 +175,7 @@ class Diagnostics:
             if lo_n == 0 and hi_n == 0:
                 print("      [OK]   All variables within supplied bounds")
             else:
+                fail = True
                 print(f"      [FAIL] Bounds violations: {lo_n} lower, {hi_n} upper")
                 self._print_violations(
                     "lower", lo_viol_mask, lo_arr - x_arr, lo_arr, x_arr
@@ -178,7 +190,9 @@ class Diagnostics:
             print("      [SKIP] No user bound vectors supplied")
 
         # --- meta-declared bounds vs user vector ---
-        self._check_meta_bounds(x_arr)
+        meta_fail = self._check_meta_bounds(x_arr)
+
+        return fail or meta_fail
 
     def _print_violations(
         self,
@@ -212,13 +226,15 @@ class Diagnostics:
                 f"x={xval:.4g}  bound={bval:.4g}{note}{meta_note}"
             )
 
-    def _check_meta_bounds(self, x_arr: np.ndarray) -> None:
+    def _check_meta_bounds(self, x_arr: np.ndarray) -> bool:
         """Warn about *input* variables where the component declared a finite,
         non-zero bound but the user's bound vector has 0 (never set).
 
         Constraint variables are skipped — their meta upper=0 is intentional
         (Amigo enforces equality constraints as c(x)=0).
         """
+        fail = False
+
         if self.upper is None or self.lower is None:
             return
 
@@ -255,6 +271,7 @@ class Diagnostics:
                         )
 
         if issues:
+            fail = True
             print(
                 "      [WARN] Component-declared bounds not reflected in user vectors:"
             )
@@ -265,9 +282,12 @@ class Diagnostics:
         else:
             print("      [OK]   Component meta bounds are consistent with user vectors")
 
+        return fail
+
     # ── check 3: connectivity ─────────────────────────────────────────────────
 
-    def _check_connectivity(self) -> None:
+    def _check_connectivity(self) -> bool:
+        fail = False
         print("\n  [3] Connectivity (potentially missing model.link() calls)")
 
         inputs, _, _, _ = self.model.get_names()
@@ -310,6 +330,7 @@ class Diagnostics:
                 )
 
         if warnings:
+            fail = True
             for w in warnings:
                 print(w)
         else:
@@ -332,25 +353,24 @@ class Diagnostics:
             if len(isolated) > self._MAX_VIOLATIONS_SHOWN:
                 print(f"             ... ({len(isolated)} total)")
 
-    # ── check 4: user-supplied constraint evaluators ──────────────────────────
+        return fail
 
-    def _check_evaluators(self, evaluators: dict) -> None:
-        print("\n  [4] Constraint residuals (user-supplied evaluators)")
+    # ── check 4: constraint residuals via model.eval_constraints ─────────────
 
-        if not evaluators:
-            print(
-                "      [SKIP] No evaluators provided.\n"
-                "             Pass evaluators={name: callable(x)->array} to check\n"
-                "             constraint residuals and estimate inf_pr."
-            )
-            return
+    def _check_constraints(self) -> bool:
+        fail = False
+        print("\n  [4] Constraint residuals (model.eval_constraints)")
+        try:
+            residuals = self.model.eval_constraints(self.x)
+        except Exception as exc:
+            print(f"      [ERR]  eval_constraints failed: {exc}")
+            fail = True
+            return fail
 
         all_max: list[float] = []
-        for name, fn in evaluators.items():
-            try:
-                arr = np.asarray(fn(self.x), dtype=float).flatten()
-            except Exception as exc:
-                print(f"      [ERR]  {name}: evaluator raised {exc}")
+        for name, arr in residuals.items():
+            arr = np.asarray(arr, dtype=float).flatten()
+            if arr.size == 0:
                 continue
             max_r = float(np.max(np.abs(arr)))
             mean_r = float(np.mean(np.abs(arr)))
@@ -365,10 +385,15 @@ class Diagnostics:
                 f"\n      {tag} inf_pr estimate = {inf_pr:.4e}"
                 f"  (should match optimizer iter-0 inf_pr)"
             )
+            if inf_pr > 1.0:
+                fail = True
+
+        return fail
 
     # ── check 5: spotlight constraints ───────────────────────────────────────
 
-    def _check_spotlights(self, spotlights: dict, tol: float) -> None:
+    def _check_spotlights(self, spotlights: dict, tol: float) -> bool:
+        fail = False
         print("\n  [5] Spotlight constraints (read from x)")
 
         if not spotlights:
@@ -380,11 +405,16 @@ class Diagnostics:
                 vals = np.asarray(self.x[cons_name], dtype=float).flatten()
             except Exception as exc:
                 print(f"      [ERR]  {cons_name}: {exc}")
+                fail = True
                 continue
             print(f"      {cons_name}:")
             for label, v in zip(labels, vals):
                 tag = "[OK]  " if abs(v) < tol else "[FAIL]"
                 print(f"        {tag} {label:14s}  val={v:.4e}")
+                if abs(v) < tol:
+                    fail = True
+
+        return fail
 
     # ── internal helpers ──────────────────────────────────────────────────────
 

--- a/amigo/diagnostics.py
+++ b/amigo/diagnostics.py
@@ -1,0 +1,402 @@
+"""
+amigo.diagnostics
+=================
+General-purpose pre-optimisation diagnostic checks for any Amigo model.
+
+Usage
+-----
+::
+
+    import amigo as am
+
+    diag = am.Diagnostics(model, x, lower, upper)
+    diag.run(
+        evaluators={
+            "ac.res":   lambda x: compute_dynamics(x),   # returns np.ndarray
+            "trap.res": lambda x: compute_trap(x),
+        },
+        spotlights={
+            "ic.res": ["velocity", "gamma", "altitude", "range", "mass"],
+            "fc.res": ["velocity", "gamma", "altitude"],
+        },
+    )
+
+The five checks
+---------------
+1. **NaN/Inf** - scan every entry of the design vector.
+2. **Bounds**  - compare x against user-supplied lower/upper vectors and
+   against component-declared meta bounds; flag zero-valued bounds that were
+   never set (``create_vector()`` defaults to 0).
+3. **Connectivity** - variables sharing the same short name across different
+   components but whose global indices don't overlap are likely missing a
+   ``model.link()`` call.
+4. **Constraint residuals** - evaluate user-supplied Python callables
+   (one per constraint group) and report ``max|res|`` / ``mean|res|`` for
+   each group.  The largest value is an estimate of ``inf_pr`` at iter 0.
+5. **Spotlight constraints** - read named constraint-residual variables
+   directly from ``x`` (useful for IC/FC whose values the user seeds during
+   initial-guess setup) and report per-element pass/fail.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # avoid circular import at runtime
+    from .model import Model, ModelVector
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+_SEP = "═" * 62
+
+
+def _strip_indices(expr: str) -> str:
+    """Remove bracket subscript from 'comp.var[0]' → 'comp.var'."""
+    return expr.split("[")[0].strip()
+
+
+# ── main class ────────────────────────────────────────────────────────────────
+
+
+class Diagnostics:
+    """Pre-optimisation health checks for an initialised Amigo model.
+
+    Parameters
+    ----------
+    model:
+        An initialised ``am.Model`` instance.
+    x:
+        Design vector returned by ``model.create_vector()`` and populated
+        with the initial guess.
+    lower, upper:
+        Optional bound vectors returned by ``model.create_vector()``.
+        When omitted, only the component-declared meta bounds are checked.
+    """
+
+    _TOL_BOUND: float = 1e-10
+    _MAX_VIOLATIONS_SHOWN: int = 5
+
+    def __init__(self, model, x, lower=None, upper=None):
+        self.model = model
+        self.x = x
+        self.lower = lower
+        self.upper = upper
+        self._idx_to_name: dict[int, str] = self._build_idx_map()
+
+    # ── public API ────────────────────────────────────────────────────────────
+
+    def run(
+        self,
+        evaluators: dict | None = None,
+        spotlights: dict | None = None,
+        tol: float = 1e-6,
+    ) -> None:
+        """Run all five checks and print a formatted report.
+
+        Parameters
+        ----------
+        evaluators:
+            ``{constraint_group_name: callable(x) -> array-like}``
+            The callable receives the ``ModelVector`` and must return the
+            constraint residuals for that group as a flat or shaped array.
+        spotlights:
+            ``{constraint_var_name: [label_0, label_1, ...]}``.
+            Each named constraint variable is read directly from ``x`` and
+            its per-element value is printed with a pass/fail tag.
+        tol:
+            Residual tolerance used for pass/fail in spotlight check.
+        """
+        evaluators = evaluators or {}
+        spotlights = spotlights or {}
+
+        nvar = self.model.num_variables
+        ncon = self.model.num_constraints
+        mname = getattr(self.model, "module_name", None) or "?"
+
+        print(f"\n{_SEP}")
+        print(f"  Amigo Diagnostics")
+        print(f"  Model: {mname!r}   Variables: {nvar}   Constraints: {ncon}")
+        print(_SEP)
+
+        self._check_nan_inf()
+        self._check_bounds()
+        self._check_connectivity()
+        self._check_evaluators(evaluators)
+        self._check_spotlights(spotlights, tol)
+
+        print(f"{_SEP}\n")
+
+    # ── check 1: NaN / Inf ────────────────────────────────────────────────────
+
+    def _check_nan_inf(self) -> None:
+        print("\n  [1] NaN / Inf in design vector")
+        x_arr = np.asarray(self.x[:], dtype=float)
+        bad = ~np.isfinite(x_arr)
+        n_bad = int(bad.sum())
+        if n_bad == 0:
+            print(f"      [OK]   No NaN/Inf ({x_arr.size} entries checked)")
+        else:
+            print(f"      [FAIL] {n_bad} non-finite entries")
+            for idx in np.where(bad)[0][: self._MAX_VIOLATIONS_SHOWN]:
+                name = self._idx_to_name.get(int(idx), f"idx={idx}")
+                print(f"             {name:40s}  val={x_arr[idx]}")
+
+    # ── check 2: bounds ───────────────────────────────────────────────────────
+
+    def _check_bounds(self) -> None:
+        print("\n  [2] Bounds analysis")
+
+        x_arr = np.asarray(self.x[:], dtype=float)
+
+        # --- user-supplied bound vectors ---
+        if self.lower is not None and self.upper is not None:
+            lo_arr = np.asarray(self.lower[:], dtype=float)
+            hi_arr = np.asarray(self.upper[:], dtype=float)
+
+            lo_viol_mask = x_arr < lo_arr - self._TOL_BOUND
+            hi_viol_mask = x_arr > hi_arr + self._TOL_BOUND
+            lo_n = int(lo_viol_mask.sum())
+            hi_n = int(hi_viol_mask.sum())
+
+            if lo_n == 0 and hi_n == 0:
+                print("      [OK]   All variables within supplied bounds")
+            else:
+                print(f"      [FAIL] Bounds violations: {lo_n} lower, {hi_n} upper")
+                self._print_violations(
+                    "lower", lo_viol_mask, lo_arr - x_arr, lo_arr, x_arr
+                )
+                self._print_violations(
+                    "upper", hi_viol_mask, x_arr - hi_arr, hi_arr, x_arr
+                )
+                total = lo_n + hi_n
+                if total > self._MAX_VIOLATIONS_SHOWN:
+                    print(f"             ... ({total} total violations)")
+        else:
+            print("      [SKIP] No user bound vectors supplied")
+
+        # --- meta-declared bounds vs user vector ---
+        self._check_meta_bounds(x_arr)
+
+    def _print_violations(
+        self,
+        side: str,
+        mask: np.ndarray,
+        gap: np.ndarray,
+        bound: np.ndarray,
+        x_arr: np.ndarray,
+    ) -> None:
+        # Retrieve meta-declared bounds for comparison
+        try:
+            meta_key = "lower" if side == "lower" else "upper"
+            meta_vec = np.asarray(
+                self.model.get_values_from_meta(meta_key)[:], dtype=float
+            )
+        except Exception:
+            meta_vec = None
+
+        indices = np.where(mask)[0]
+        worst = indices[np.argsort(gap[indices])[::-1]][: self._MAX_VIOLATIONS_SHOWN]
+        for idx in worst:
+            name = self._idx_to_name.get(int(idx), f"idx={idx}")
+            bval = bound[idx]
+            xval = x_arr[idx]
+            note = "  [unset?]" if bval == 0.0 else ""
+            meta_note = ""
+            if meta_vec is not None and np.isfinite(meta_vec[idx]):
+                meta_note = f"  [component declared: {meta_vec[idx]:.4g}]"
+            print(
+                f"             {side} {name:35s}  "
+                f"x={xval:.4g}  bound={bval:.4g}{note}{meta_note}"
+            )
+
+    def _check_meta_bounds(self, x_arr: np.ndarray) -> None:
+        """Warn about *input* variables where the component declared a finite,
+        non-zero bound but the user's bound vector has 0 (never set).
+
+        Constraint variables are skipped — their meta upper=0 is intentional
+        (Amigo enforces equality constraints as c(x)=0).
+        """
+        if self.upper is None or self.lower is None:
+            return
+
+        # Only examine input variables; constraint variables are equality
+        # constraints whose upper/lower = 0 is correct by design.
+        input_names, _, _, _ = self.model.get_names()
+
+        issues = []
+        for side, meta_key, user_vec_attr in (
+            ("upper", "upper", "upper"),
+            ("lower", "lower", "lower"),
+        ):
+            try:
+                meta_vec_model = self.model.get_values_from_meta(meta_key)
+            except Exception:
+                continue
+            user_vec = np.asarray(getattr(self, user_vec_attr)[:], dtype=float)
+
+            for vname in input_names:
+                try:
+                    idxs = np.atleast_1d(self.model.get_indices(vname)).flatten()
+                    meta_vals = np.asarray(meta_vec_model[vname], dtype=float).flatten()
+                except Exception:
+                    continue
+                for local_i, (idx, mv) in enumerate(zip(idxs, meta_vals)):
+                    uv = user_vec[int(idx)]
+                    # Flag only when the component declared a *meaningful* finite
+                    # bound (non-zero, non-inf) but the user vector is still 0.
+                    if np.isfinite(mv) and mv != 0.0 and uv == 0.0:
+                        label = f"{vname}[{local_i}]" if len(idxs) > 1 else vname
+                        issues.append(
+                            f"             {side} {label:40s}  "
+                            f"component declared {mv:.4g}, user vector = 0 [unset?]"
+                        )
+
+        if issues:
+            print(
+                "      [WARN] Component-declared bounds not reflected in user vectors:"
+            )
+            for line in issues[: self._MAX_VIOLATIONS_SHOWN]:
+                print(line)
+            if len(issues) > self._MAX_VIOLATIONS_SHOWN:
+                print(f"             ... ({len(issues)} total)")
+        else:
+            print("      [OK]   Component meta bounds are consistent with user vectors")
+
+    # ── check 3: connectivity ─────────────────────────────────────────────────
+
+    def _check_connectivity(self) -> None:
+        print("\n  [3] Connectivity (potentially missing model.link() calls)")
+
+        inputs, _, _, _ = self.model.get_names()
+
+        # Variables that appear as source or target in any link
+        linked_src: set[str] = set()
+        linked_tgt: set[str] = set()
+        for src_expr, _, tgt_expr, _ in self.model.links:
+            linked_src.add(_strip_indices(src_expr))
+            linked_tgt.add(_strip_indices(tgt_expr))
+
+        # Group inputs by their short name (last segment)
+        short_map: dict[str, list[str]] = defaultdict(list)
+        for full in inputs:
+            short = full.rsplit(".", 1)[-1]
+            short_map[short].append(full)
+
+        warnings: list[str] = []
+        for short, full_names in short_map.items():
+            if len(full_names) < 2:
+                continue
+            # Check whether any pair shares global indices (i.e. is linked)
+            try:
+                idx_sets = [
+                    set(np.atleast_1d(self.model.get_indices(n)).tolist())
+                    for n in full_names
+                ]
+            except Exception:
+                continue
+            # If NO pair shares indices, none of them are linked together
+            any_shared = any(
+                len(idx_sets[i] & idx_sets[j]) > 0
+                for i in range(len(idx_sets))
+                for j in range(i + 1, len(idx_sets))
+            )
+            if not any_shared:
+                warnings.append(
+                    f"      [WARN] '{short}' appears in {full_names} "
+                    f"but indices don't overlap — missing link?"
+                )
+
+        if warnings:
+            for w in warnings:
+                print(w)
+        else:
+            print("      [OK]   No shared-name unlinked variables detected")
+
+        # Isolated inputs (not in any link at all)
+        isolated = [
+            n
+            for n in inputs
+            if _strip_indices(n) not in linked_src
+            and _strip_indices(n) not in linked_tgt
+        ]
+        if isolated:
+            print(
+                f"      [INFO] {len(isolated)} input(s) not in any link "
+                f"(may be intentional standalone design variables):"
+            )
+            for name in isolated[: self._MAX_VIOLATIONS_SHOWN]:
+                print(f"             {name}")
+            if len(isolated) > self._MAX_VIOLATIONS_SHOWN:
+                print(f"             ... ({len(isolated)} total)")
+
+    # ── check 4: user-supplied constraint evaluators ──────────────────────────
+
+    def _check_evaluators(self, evaluators: dict) -> None:
+        print("\n  [4] Constraint residuals (user-supplied evaluators)")
+
+        if not evaluators:
+            print(
+                "      [SKIP] No evaluators provided.\n"
+                "             Pass evaluators={name: callable(x)->array} to check\n"
+                "             constraint residuals and estimate inf_pr."
+            )
+            return
+
+        all_max: list[float] = []
+        for name, fn in evaluators.items():
+            try:
+                arr = np.asarray(fn(self.x), dtype=float).flatten()
+            except Exception as exc:
+                print(f"      [ERR]  {name}: evaluator raised {exc}")
+                continue
+            max_r = float(np.max(np.abs(arr)))
+            mean_r = float(np.mean(np.abs(arr)))
+            all_max.append(max_r)
+            flag = "  [!!]" if max_r > 1.0 else "      "
+            print(f"  {flag}  {name:38s}  max={max_r:.4e}  mean={mean_r:.4e}")
+
+        if all_max:
+            inf_pr = max(all_max)
+            tag = "[WARN]" if inf_pr > 1.0 else "[OK]  "
+            print(
+                f"\n      {tag} inf_pr estimate = {inf_pr:.4e}"
+                f"  (should match optimizer iter-0 inf_pr)"
+            )
+
+    # ── check 5: spotlight constraints ───────────────────────────────────────
+
+    def _check_spotlights(self, spotlights: dict, tol: float) -> None:
+        print("\n  [5] Spotlight constraints (read from x)")
+
+        if not spotlights:
+            print("      [SKIP] No spotlights specified.")
+            return
+
+        for cons_name, labels in spotlights.items():
+            try:
+                vals = np.asarray(self.x[cons_name], dtype=float).flatten()
+            except Exception as exc:
+                print(f"      [ERR]  {cons_name}: {exc}")
+                continue
+            print(f"      {cons_name}:")
+            for label, v in zip(labels, vals):
+                tag = "[OK]  " if abs(v) < tol else "[FAIL]"
+                print(f"        {tag} {label:14s}  val={v:.4e}")
+
+    # ── internal helpers ──────────────────────────────────────────────────────
+
+    def _build_idx_map(self) -> dict[int, str]:
+        """Map each global variable index to a human-readable name."""
+        idx_to_name: dict[int, str] = {}
+        inputs, cons, _, _ = self.model.get_names()
+        for vname in inputs + cons:
+            try:
+                idxs = np.atleast_1d(self.model.get_indices(vname))
+                for i, idx in enumerate(idxs):
+                    idx_to_name[int(idx)] = f"{vname}[{i}]"
+            except Exception:
+                pass
+        return idx_to_name

--- a/amigo/model.py
+++ b/amigo/model.py
@@ -1165,49 +1165,6 @@ class Model:
     def eval_hessian(self, x: ModelVector, mat: CSRMat, alpha: float = 1.0):
         self.problem.hessian(alpha, x.get_vector(), mat)
 
-    def eval_constraints(self, x: ModelVector) -> dict:
-        """Evaluate all constraint functions at x without running the optimizer.
-
-        Uses the gradient infrastructure: with alpha=0, the gradient vector g
-        is zeroed at primal positions (no objective contribution), and entries
-        at the multiplier positions contain c(x) for every equality constraint.
-        This follows the KKT structure where g[mult] = c(x).
-
-        Returns
-        -------
-        dict
-            Maps each constraint group name (e.g. ``"ac.res"``, ``"trap.res"``)
-            to a numpy array of residual values evaluated at x.
-
-        Raises
-        ------
-        RuntimeError
-            If the total size of named constraint groups does not match the
-            number of multiplier variables, indicating an ordering mismatch.
-        """
-        g = self.create_vector()
-        self.eval_gradient(x, g, alpha=0.0)
-        g_arr = np.asarray(g[:], dtype=float)
-
-        mult_mask = np.asarray(self.problem.get_multiplier_indicator(), dtype=bool)
-        c_flat = g_arr[mult_mask]
-
-        result = {}
-        k = 0
-        _, cons_names, _, _ = self.get_names()
-        for name in cons_names:
-            n = int(np.atleast_1d(self.get_indices(name)).size)
-            result[name] = c_flat[k : k + n]
-            k += n
-
-        if k != len(c_flat):
-            raise RuntimeError(
-                f"eval_constraints: named constraints sum to {k} entries "
-                f"but multiplier vector has {len(c_flat)}. "
-                "Constraint ordering mismatch — please report this as a bug."
-            )
-        return result
-
     def compute_output(self, x: ModelVector, output: ModelVector):
         return self.problem.compute_output(x.get_vector(), output.get_vector())
 

--- a/amigo/model.py
+++ b/amigo/model.py
@@ -1164,6 +1164,49 @@ class Model:
     def eval_hessian(self, x: ModelVector, mat: CSRMat, alpha: float = 1.0):
         self.problem.hessian(alpha, x.get_vector(), mat)
 
+    def eval_constraints(self, x: ModelVector) -> dict:
+        """Evaluate all constraint functions at x without running the optimizer.
+
+        Uses the gradient infrastructure: with alpha=0, the gradient vector g
+        is zeroed at primal positions (no objective contribution), and entries
+        at the multiplier positions contain c(x) for every equality constraint.
+        This follows the KKT structure where g[mult] = c(x).
+
+        Returns
+        -------
+        dict
+            Maps each constraint group name (e.g. ``"ac.res"``, ``"trap.res"``)
+            to a numpy array of residual values evaluated at x.
+
+        Raises
+        ------
+        RuntimeError
+            If the total size of named constraint groups does not match the
+            number of multiplier variables, indicating an ordering mismatch.
+        """
+        g = self.create_vector()
+        self.eval_gradient(x, g, alpha=0.0)
+        g_arr = np.asarray(g[:], dtype=float)
+
+        mult_mask = np.asarray(self.problem.get_multiplier_indicator(), dtype=bool)
+        c_flat = g_arr[mult_mask]
+
+        result = {}
+        k = 0
+        _, cons_names, _, _ = self.get_names()
+        for name in cons_names:
+            n = int(np.atleast_1d(self.get_indices(name)).size)
+            result[name] = c_flat[k : k + n]
+            k += n
+
+        if k != len(c_flat):
+            raise RuntimeError(
+                f"eval_constraints: named constraints sum to {k} entries "
+                f"but multiplier vector has {len(c_flat)}. "
+                "Constraint ordering mismatch — please report this as a bug."
+            )
+        return result
+
     def compute_output(self, x: ModelVector, output: ModelVector):
         return self.problem.compute_output(x.get_vector(), output.get_vector())
 

--- a/examples/time_to_climb/time_to_climb.py
+++ b/examples/time_to_climb/time_to_climb.py
@@ -370,7 +370,6 @@ upper["bspline.control_points.x"] = 25.0
 am.Diagnostics(model, x, lower, upper).run()
 
 # Optimize
-opt = am.Optimizer(model, x, lower=lower, upper=upper)
 opt = am.Optimizer(model, x, lower=lower, upper=upper, solver="mumps")
 data = opt.optimize(
     {

--- a/examples/time_to_climb/time_to_climb.py
+++ b/examples/time_to_climb/time_to_climb.py
@@ -367,6 +367,8 @@ upper["ac.q[:, 2]"] = 25.0
 lower["bspline.control_points.x"] = -25.0
 upper["bspline.control_points.x"] = 25.0
 
+am.Diagnostics(model, x, lower, upper).run()
+
 # Optimize
 opt = am.Optimizer(model, x, lower=lower, upper=upper)
 opt = am.Optimizer(model, x, lower=lower, upper=upper, solver="mumps")

--- a/examples/time_to_climb/time_to_climb.py
+++ b/examples/time_to_climb/time_to_climb.py
@@ -369,6 +369,7 @@ upper["bspline.control_points.x"] = 25.0
 
 # Optimize
 opt = am.Optimizer(model, x, lower=lower, upper=upper)
+opt = am.Optimizer(model, x, lower=lower, upper=upper, solver="mumps")
 data = opt.optimize(
     {
         "initial_barrier_param": 1.0,

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,4 @@
+# Specific .gitignore for tests
+CMakeLists.txt
+*.cpp
+*.h

--- a/tests/interp/test_smt_quadratic.py
+++ b/tests/interp/test_smt_quadratic.py
@@ -87,7 +87,7 @@ def opt_result(trained_krg):
     lower["src.y"] = 0.25
     upper["src.y"] = float("inf")
 
-    opt = am.Optimizer(model, xvec, lower=lower, upper=upper)
+    opt = am.Optimizer(model, xvec, lower=lower, upper=upper, solver="mumps")
     data = opt.optimize(
         {
             "max_iterations": 200,


### PR DESCRIPTION
# Summary
Add a diagnostics tool that helps validate the setup of a model/optimization problem. **Also:** split pytest workflow into separate workflows for different operating systems.

Currently checks five things:
1. **NaN/Inf** - scan every entry of the design vector.
2. **Bounds**  - compare x against user-supplied lower/upper vectors and
   against component-declared meta bounds; flag zero-valued bounds that were
   never set (``create_vector()`` defaults to 0).
3. **Connectivity** - variables sharing the same short name across different
   components but whose global indices don't overlap are likely missing a
   ``model.link()`` call.
4. **Constraint residuals** - evaluate all constraints using
   ``model.eval_constraints(x)`` and report ``max|res|`` / ``mean|res|`` for
   each group.  The largest value is an estimate of ``inf_pr`` at iter 0.
5. **Spotlight constraints** - read named constraint-residual variables
   directly from ``x`` (useful for IC/FC whose values the user seeds during
   initial-guess setup) and report per-element pass/fail.


## Example Output
```
Num variables:              1442
Num constraints:            717

══════════════════════════════════════════════════════════════
  Amigo Diagnostics
  Model: 'time_to_climb'   Variables: 1442   Constraints: 717
══════════════════════════════════════════════════════════════

  [1] NaN / Inf in design vector
      [OK]   No NaN/Inf (1442 entries checked)

  [2] Bounds analysis
      [OK]   All variables within supplied bounds
      [OK]   Component meta bounds are consistent with user vectors

  [3] Connectivity (potentially missing model.link() calls)
      [OK]   No shared-name unlinked variables detected
      [INFO] 3 input(s) not in any link (may be intentional standalone design variables):
             ac.thrust
             tw.Mach
             tw.alt

  [4] Constraint residuals (model.eval_constraints)
          ac.res                                  max=2.2204e-15  mean=1.8579e-17
    [!!]  trap.res                                max=1.4777e+01  mean=1.8222e+00
    [!!]  bspline.kernel.constraint               max=2.4678e+00  mean=7.5041e-01
          ic.res                                  max=0.0000e+00  mean=0.0000e+00
    [!!]  fc.res                                  max=9.4682e+00  mean=3.1561e+00
          tw.con_mach                             max=0.0000e+00  mean=0.0000e+00
          tw.con_alt                              max=0.0000e+00  mean=0.0000e+00
          smt_con.smt_res                         max=0.0000e+00  mean=0.0000e+00

      [WARN] inf_pr estimate = 1.4777e+01  (should match optimizer iter-0 inf_pr)

  [5] Spotlight constraints (read from x)
      [SKIP] No spotlights specified.
══════════════════════════════════════════════════════════════
```