### PR TITLE
Create unit tests

### DIFF
--- a/.github/workflows/pytest-windows.yml
+++ b/.github/workflows/pytest-windows.yml
@@ -1,9 +1,9 @@
 name: pytest (Windows)
 
 on:
-  #push:
-  #  branches: [main]
-  #pull_request:
+  push:
+   branches: [main]
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+# pytest package discovery

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,20 @@
+"""
+Stub out compiled extensions and heavy dependencies before any amigo.model
+import occurs, so that the pure-Python helpers can be imported without a
+C++ build, MUMPS, or SMT installation.
+"""
+import sys
+from unittest.mock import MagicMock
+
+for mod in [
+    "amigo.amigo",
+    "mpi4py",
+    "mpi4py.MPI",
+    "pybind11",
+    "scipy",
+    "scipy.sparse",
+    "scipy.sparse.linalg",
+    "scipy.interpolate",
+    "networkx",
+]:
+    sys.modules.setdefault(mod, MagicMock())

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,7 @@ Stub out compiled extensions and heavy dependencies before any amigo.model
 import occurs, so that the pure-Python helpers can be imported without a
 C++ build, MUMPS, or SMT installation.
 """
+
 import sys
 from unittest.mock import MagicMock
 

--- a/tests/unit/test_block_detection.py
+++ b/tests/unit/test_block_detection.py
@@ -1,0 +1,195 @@
+"""
+Unit tests for amigo/block_detection.py.
+
+Covers the internal helpers and the top-level block detection function used
+by the BISC convexifier to identify block structure in the KKT sparsity pattern.
+
+Test areas:
+  - _compute_degrees(): counts primal-primal edges per variable; multiplier
+    (dual) rows always have degree 0.
+  - _find_connected_components(): BFS-based connected component detection on
+    a primal adjacency structure.
+  - detect_bfs_level_blocks(): top-level function that classifies primal
+    variables into small blocks (direct eigendecomp), BFS chains (block-
+    tridiagonal Schur propagation), and hub variables (high-degree nodes).
+
+All tests use hand-crafted CSR arrays (rowp, cols, mult_ind) so no compiled
+extension or solver is required.
+"""
+
+import numpy as np
+import pytest
+
+from amigo.block_detection import (
+    detect_bfs_level_blocks,
+    _compute_degrees,
+    _find_connected_components,
+    _build_primal_adjacency,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_linear_chain_csr(n):
+    """Build CSR arrays for a symmetric linear chain of n nodes."""
+    rowp = [0]
+    cols = []
+    for i in range(n):
+        neighbors = []
+        if i > 0:
+            neighbors.append(i - 1)
+        if i < n - 1:
+            neighbors.append(i + 1)
+        cols.extend(neighbors)
+        rowp.append(rowp[-1] + len(neighbors))
+    return np.array(rowp), np.array(cols, dtype=np.int64)
+
+
+# ---------------------------------------------------------------------------
+# _compute_degrees — primal-primal degree per variable
+#
+# Counts the number of primal (non-multiplier) neighbours for each variable.
+# Multiplier rows (dual variables) are excluded from both the count and the
+# neighbour set, so their degree is always 0.
+# ---------------------------------------------------------------------------
+
+class TestComputeDegrees:
+    """_compute_degrees: multiplier rows have degree 0; primal degrees are correct."""
+    def test_multiplier_row_has_zero_degree(self):
+        """Multiplier (dual) rows must always have degree 0."""
+        # 3-node graph: node 0 is a multiplier, nodes 1 and 2 are primal
+        # Edges: 1-2 (symmetric)
+        rowp = np.array([0, 2, 4, 6])
+        cols = np.array([1, 2, 0, 2, 0, 1])
+        mult_ind = np.array([True, False, False])
+
+        degree = _compute_degrees(rowp, cols, mult_ind)
+
+        assert degree[0] == 0, "Multiplier node must have degree 0"
+
+    def test_triangle_graph_degrees(self):
+        """All-primal triangle: each node has primal-primal degree 2."""
+        # Symmetric triangle: 0-1, 0-2, 1-2
+        rowp = np.array([0, 2, 4, 6])
+        cols = np.array([1, 2, 0, 2, 0, 1])
+        mult_ind = np.array([False, False, False])
+
+        degree = _compute_degrees(rowp, cols, mult_ind)
+
+        assert degree[0] == 2
+        assert degree[1] == 2
+        assert degree[2] == 2
+
+
+# ---------------------------------------------------------------------------
+# _find_connected_components — BFS connected component detection
+#
+# Operates on the primal adjacency structure produced by _build_primal_adjacency.
+# Returns a list of components, each a list of variable indices.
+# ---------------------------------------------------------------------------
+
+class TestFindConnectedComponents:
+    """_find_connected_components: single component and multi-component graphs."""
+    def test_single_component_triangle(self):
+        """Fully connected triangle → exactly one component with all 3 nodes."""
+        rowp = np.array([0, 2, 4, 6])
+        cols = np.array([1, 2, 0, 2, 0, 1])
+        mult_ind = np.array([False, False, False])
+
+        primal_indices, primal_set, adj = _build_primal_adjacency(
+            rowp, cols, mult_ind, hub_set=set()
+        )
+        components = _find_connected_components(primal_indices, primal_set, adj)
+
+        assert len(components) == 1
+        assert sorted(components[0]) == [0, 1, 2]
+
+    def test_two_disconnected_components(self):
+        """Nodes 0-1 connected, nodes 2-3 connected → two components."""
+        # 4 nodes: 0-1 connected, 2-3 connected, no cross edges
+        rowp = np.array([0, 1, 2, 3, 4])
+        cols = np.array([1, 0, 3, 2])
+        mult_ind = np.array([False, False, False, False])
+
+        primal_indices, primal_set, adj = _build_primal_adjacency(
+            rowp, cols, mult_ind, hub_set=set()
+        )
+        components = _find_connected_components(primal_indices, primal_set, adj)
+
+        assert len(components) == 2
+
+        # Each component should be one of the two pairs
+        component_sets = [frozenset(c) for c in components]
+        assert frozenset({0, 1}) in component_sets
+        assert frozenset({2, 3}) in component_sets
+
+
+# ---------------------------------------------------------------------------
+# detect_bfs_level_blocks — top-level block classification
+#
+# Classifies all primal variables into:
+#   small_blocks  — components small enough for direct eigendecomposition
+#   bfs_chains    — large chain-structured components (block-tridiagonal)
+#   hub_indices   — high-degree variables isolated as scalar blocks
+#
+# The function accepts max_eigendecomp_size and max_block_size thresholds
+# that control when a component is treated as a chain vs. small blocks.
+# ---------------------------------------------------------------------------
+
+class TestDetectBfsLevelBlocks:
+    """detect_bfs_level_blocks: isolated nodes, disconnected components, and chain overflow."""
+    def test_single_isolated_primal_variable(self):
+        """Single isolated primal node → one small block, no chains."""
+        rowp = np.array([0, 0])
+        cols = np.array([], dtype=np.int64)
+        mult_ind = np.array([False])
+
+        small_blocks, bfs_chains, hub_indices = detect_bfs_level_blocks(
+            rowp, cols, mult_ind
+        )
+
+        assert len(small_blocks) == 1, "Expected exactly one small block"
+        assert len(bfs_chains) == 0, "Expected no BFS chains"
+        assert list(small_blocks[0]) == [0]
+
+    def test_two_disconnected_components_become_two_small_blocks(self):
+        """Two disconnected 2-node components → two small blocks (size <= 20)."""
+        rowp = np.array([0, 1, 2, 3, 4])
+        cols = np.array([1, 0, 3, 2])
+        mult_ind = np.array([False, False, False, False])
+
+        small_blocks, bfs_chains, hub_indices = detect_bfs_level_blocks(
+            rowp, cols, mult_ind
+        )
+
+        # Both components have size 2 <= max_eigendecomp_size=20 → small blocks
+        assert len(small_blocks) == 2
+        assert len(bfs_chains) == 0
+
+        all_nodes = sorted(n for block in small_blocks for n in block.tolist())
+        assert all_nodes == [0, 1, 2, 3]
+
+    def test_large_chain_with_max_block_size_zero_becomes_small_blocks(self):
+        """Linear chain of 25 nodes with max_block_size=0 → all small blocks, no chains."""
+        n = 25
+        rowp, cols = make_linear_chain_csr(n)
+        mult_ind = np.array([False] * n)
+
+        small_blocks, bfs_chains, hub_indices = detect_bfs_level_blocks(
+            rowp,
+            cols,
+            mult_ind,
+            max_block_size=0,   # any level size > 0 triggers conversion
+            max_eigendecomp_size=20,
+        )
+
+        # With max_block_size=0, every BFS level (size >= 1) exceeds the limit,
+        # so the chain is broken into individual small blocks.
+        assert len(bfs_chains) == 0, "Expected no BFS chains when max_block_size=0"
+
+        # All 25 nodes should appear in small_blocks
+        all_nodes = sorted(n for block in small_blocks for n in block.tolist())
+        assert len(all_nodes) == n
+        assert all_nodes == list(range(n))

--- a/tests/unit/test_block_detection.py
+++ b/tests/unit/test_block_detection.py
@@ -32,6 +32,7 @@ from amigo.block_detection import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def make_linear_chain_csr(n):
     """Build CSR arrays for a symmetric linear chain of n nodes."""
     rowp = [0]
@@ -55,8 +56,10 @@ def make_linear_chain_csr(n):
 # neighbour set, so their degree is always 0.
 # ---------------------------------------------------------------------------
 
+
 class TestComputeDegrees:
     """_compute_degrees: multiplier rows have degree 0; primal degrees are correct."""
+
     def test_multiplier_row_has_zero_degree(self):
         """Multiplier (dual) rows must always have degree 0."""
         # 3-node graph: node 0 is a multiplier, nodes 1 and 2 are primal
@@ -90,8 +93,10 @@ class TestComputeDegrees:
 # Returns a list of components, each a list of variable indices.
 # ---------------------------------------------------------------------------
 
+
 class TestFindConnectedComponents:
     """_find_connected_components: single component and multi-component graphs."""
+
     def test_single_component_triangle(self):
         """Fully connected triangle → exactly one component with all 3 nodes."""
         rowp = np.array([0, 2, 4, 6])
@@ -138,8 +143,10 @@ class TestFindConnectedComponents:
 # that control when a component is treated as a chain vs. small blocks.
 # ---------------------------------------------------------------------------
 
+
 class TestDetectBfsLevelBlocks:
     """detect_bfs_level_blocks: isolated nodes, disconnected components, and chain overflow."""
+
     def test_single_isolated_primal_variable(self):
         """Single isolated primal node → one small block, no chains."""
         rowp = np.array([0, 0])
@@ -181,7 +188,7 @@ class TestDetectBfsLevelBlocks:
             rowp,
             cols,
             mult_ind,
-            max_block_size=0,   # any level size > 0 triggers conversion
+            max_block_size=0,  # any level size > 0 triggers conversion
             max_eigendecomp_size=20,
         )
 

--- a/tests/unit/test_component.py
+++ b/tests/unit/test_component.py
@@ -1,0 +1,153 @@
+"""
+Unit tests for amigo/component.py.
+
+Covers the Meta metadata class and the InputSet, ConstantSet, and DataSet
+container classes.
+
+Test areas:
+  - Meta construction validation: rejects names with double underscores,
+    inverted bounds, out-of-range values, wrong value types, and unknown
+    keyword arguments; accepts valid inputs with correct defaults.
+  - Meta.serialize() / Meta.deserialize(): round-trip fidelity for all fields.
+  - InputSet: add() grows the collection, __getitem__ returns an active VarNode
+    Expr, and missing keys raise KeyError.
+  - ConstantSet: add() stores a ConstNode with the correct value; non-scalar
+    shapes are rejected.
+  - DataSet: add() stores an inactive VarNode Expr with the correct shape.
+"""
+import pytest
+from amigo.component import Meta, InputSet, ConstantSet, DataSet
+from amigo.expressions import VarNode, ConstNode, Expr
+
+
+# ---------------------------------------------------------------------------
+# Meta — construction validation
+#
+# Meta stores name, var_type, bounds, value, type, scale, units, and label
+# for a component variable. It validates inputs at construction time.
+# ---------------------------------------------------------------------------
+
+class TestMetaValidation:
+    """Meta construction: validation rules and serialize/deserialize round-trip."""
+
+    # Names containing "__" are reserved for internal amigo identifiers
+    def test_name_with_double_underscore_raises(self):
+        with pytest.raises(ValueError):
+            Meta("bad__name", "input")
+
+    # Bounds must satisfy lower <= upper
+    def test_lower_greater_than_upper_raises(self):
+        with pytest.raises(ValueError):
+            Meta("x", "input", lower=10.0, upper=1.0)
+
+    # For input variables the initial value must lie within [lower, upper]
+    def test_input_value_outside_bounds_raises(self):
+        with pytest.raises(ValueError):
+            Meta("x", "input", value=5.0, lower=0.0, upper=4.0)
+
+    # The value must be an instance of the declared type (default float)
+    def test_value_wrong_type_raises(self):
+        # default type is float; passing int 1 raises TypeError because isinstance(1, float) is False
+        with pytest.raises(TypeError):
+            Meta("x", "input", value=1)
+
+    # value=1 with type=int is valid (isinstance(1, int) is True)
+    def test_value_correct_int_type_succeeds(self):
+        m = Meta("x", "input", value=1, type=int)
+        assert m.value == 1
+        assert m.type is int
+
+    # Unknown keyword arguments are not silently ignored
+    def test_unknown_kwarg_raises(self):
+        with pytest.raises(ValueError):
+            Meta("x", "input", unknown_kwarg=42)
+
+    # Default bounds are (-inf, +inf) with value=0.0 and type=float
+    def test_valid_meta_defaults(self):
+        m = Meta("x", "input")
+        assert m["lower"] == float("-inf")
+        assert m["upper"] == float("inf")
+        assert m["value"] == 0.0
+        assert m["type"] is float
+
+    # serialize() produces a plain dict; deserialize() reconstructs identical fields
+    def test_serialize_deserialize_roundtrip(self):
+        m = Meta("y", "constraint", lower=-1.0, upper=1.0, value=0.0)
+        data = m.serialize()
+        # deserialize pops from the dict, so pass a copy
+        m2 = Meta.deserialize(dict(data))
+        assert m2.name == m.name
+        assert m2.var_type == m.var_type
+        assert m2.lower == m.lower
+        assert m2.upper == m.upper
+        assert m2.value == m.value
+        assert m2.type is m.type
+        assert m2.units == m.units
+        assert m2.scale == m.scale
+        assert m2.label == m.label
+
+
+# ---------------------------------------------------------------------------
+# InputSet — named active-variable container
+#
+# InputSet holds named Expr objects backed by active VarNodes. It is used
+# to declare the design variables of a Component.
+# ---------------------------------------------------------------------------
+
+class TestInputSet:
+    """InputSet: add(), __getitem__, and missing-key error behaviour."""
+
+    def test_add_increases_len(self):
+        inputs = InputSet()
+        assert len(inputs) == 0
+        inputs.add("x")
+        assert len(inputs) == 1
+
+    def test_getitem_returns_expr_with_active_varnode(self):
+        inputs = InputSet()
+        inputs.add("x")
+        expr = inputs["x"]
+        assert isinstance(expr, Expr)
+        assert isinstance(expr.node, VarNode)
+        assert expr.node.active is True
+
+    def test_getitem_missing_key_raises_keyerror(self):
+        inputs = InputSet()
+        with pytest.raises(KeyError):
+            _ = inputs["missing"]
+
+
+# ---------------------------------------------------------------------------
+# ConstantSet — named scalar constant container
+# DataSet — named passive (non-differentiable) data container
+# ---------------------------------------------------------------------------
+
+class TestConstantSet:
+    """ConstantSet: stores scalar ConstNode values; rejects non-scalar shapes."""
+
+    def test_add_stores_constnode_with_correct_value(self):
+        consts = ConstantSet()
+        consts.add("c", 3.14)
+        expr = consts["c"]
+        assert isinstance(expr, Expr)
+        assert isinstance(expr.node, ConstNode)
+        assert expr.node.value == 3.14
+
+    def test_add_non_scalar_shape_raises_valueerror(self):
+        consts = ConstantSet()
+        with pytest.raises(ValueError):
+            consts.add("c", 1.0, shape=(3,))
+
+
+class TestDataSet:
+    """DataSet: stores inactive VarNode Exprs with the declared shape."""
+
+    def test_add_stores_varnode_inactive_with_shape(self):
+        data = DataSet()
+        data.add("d", shape=(3,))
+        expr = data["d"]
+        assert isinstance(expr, Expr)
+        node = expr.node
+        assert isinstance(node, VarNode)
+        assert node.active is False
+        assert node.shape == (3,)

--- a/tests/unit/test_component.py
+++ b/tests/unit/test_component.py
@@ -15,6 +15,7 @@ Test areas:
     shapes are rejected.
   - DataSet: add() stores an inactive VarNode Expr with the correct shape.
 """
+
 import pytest
 from amigo.component import Meta, InputSet, ConstantSet, DataSet
 from amigo.expressions import VarNode, ConstNode, Expr
@@ -26,6 +27,7 @@ from amigo.expressions import VarNode, ConstNode, Expr
 # Meta stores name, var_type, bounds, value, type, scale, units, and label
 # for a component variable. It validates inputs at construction time.
 # ---------------------------------------------------------------------------
+
 
 class TestMetaValidation:
     """Meta construction: validation rules and serialize/deserialize round-trip."""
@@ -94,6 +96,7 @@ class TestMetaValidation:
 # to declare the design variables of a Component.
 # ---------------------------------------------------------------------------
 
+
 class TestInputSet:
     """InputSet: add(), __getitem__, and missing-key error behaviour."""
 
@@ -121,6 +124,7 @@ class TestInputSet:
 # ConstantSet — named scalar constant container
 # DataSet — named passive (non-differentiable) data container
 # ---------------------------------------------------------------------------
+
 
 class TestConstantSet:
     """ConstantSet: stores scalar ConstNode values; rejects non-scalar shapes."""

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -1,0 +1,435 @@
+"""
+Unit tests for amigo/expressions.py.
+
+Covers the ExprNode subclass hierarchy (ConstNode, VarNode, IndexNode,
+PassiveNode, UnaryNode, BinaryNode) and the Expr wrapper class.
+
+Test areas:
+  - is_zero(): zero-value detection and propagation through unary nodes
+  - is_active(): active/passive flag behaviour for each node type
+  - compute_cost(): operation cost increments (sqrt +20, trig/exp +100, log +200,
+    negation/fabs +1, division +10, addition/subtraction/multiplication +1)
+  - to_cpp(): C++ code generation strings for all node types
+  - Expr arithmetic operators: zero-propagation shortcuts in __add__, __sub__,
+    __mul__, __truediv__, __pow__, __neg__, and their reflected variants
+  - Expr.serialize() / Expr.deserialize(): round-trip fidelity for all node types
+  - _normalize_shape(): shape normalisation and validation
+"""
+import pytest
+from amigo.expressions import (
+    Expr,
+    ConstNode,
+    VarNode,
+    IndexNode,
+    PassiveNode,
+    UnaryNode,
+    BinaryNode,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_zero() — zero-value detection on each node type
+# ---------------------------------------------------------------------------
+
+class TestIsZero:
+    def test_const_zero_int(self):
+        assert ConstNode(value=0).is_zero() is True
+
+    def test_const_zero_float(self):
+        assert ConstNode(value=0.0).is_zero() is True
+
+    def test_const_nonzero(self):
+        assert ConstNode(value=1).is_zero() is False
+
+    def test_var_is_never_zero(self):
+        assert VarNode("x").is_zero() is False
+
+    def test_unary_neg_propagates_zero(self):
+        # UnaryNode wraps an Expr, not a bare ExprNode
+        zero_expr = Expr(ConstNode(value=0))
+        node = UnaryNode("-", zero_expr)
+        assert node.is_zero() is True
+
+    def test_unary_neg_nonzero(self):
+        nonzero_expr = Expr(VarNode("x"))
+        node = UnaryNode("-", nonzero_expr)
+        assert node.is_zero() is False
+
+
+# ---------------------------------------------------------------------------
+# is_active() — active/passive flag for each node type
+# ---------------------------------------------------------------------------
+
+class TestIsActive:
+    def test_const_is_never_active(self):
+        assert ConstNode(value=1.0).is_active() is False
+
+    def test_const_named_is_never_active(self):
+        assert ConstNode(name="c").is_active() is False
+
+    def test_var_active_true(self):
+        assert VarNode("x", active=True).is_active() is True
+
+    def test_var_active_false(self):
+        assert VarNode("x", active=False).is_active() is False
+
+    def test_passive_node_is_never_active_even_when_inner_is_active(self):
+        active_expr = Expr(VarNode("x", active=True))
+        node = PassiveNode(active_expr)
+        assert node.is_active() is False
+
+    def test_passive_node_is_never_active_when_inner_is_inactive(self):
+        inactive_expr = Expr(VarNode("x", active=False))
+        node = PassiveNode(inactive_expr)
+        assert node.is_active() is False
+
+
+# ---------------------------------------------------------------------------
+# compute_cost() — operation cost increments for each node type
+# ---------------------------------------------------------------------------
+
+class TestComputeCost:
+    def test_const_cost_is_zero(self):
+        assert ConstNode(value=5.0).compute_cost() == 0
+
+    def test_var_cost_is_zero(self):
+        assert VarNode("x").compute_cost() == 0
+
+    def test_unary_sqrt_cost(self):
+        base_expr = Expr(VarNode("x"))
+        node = UnaryNode("sqrt", base_expr)
+        assert node.compute_cost() == base_expr.compute_cost() + 20
+
+    def test_unary_sin_cost(self):
+        base_expr = Expr(VarNode("x"))
+        node = UnaryNode("sin", base_expr)
+        assert node.compute_cost() == base_expr.compute_cost() + 100
+
+    def test_unary_log_cost(self):
+        base_expr = Expr(VarNode("x"))
+        node = UnaryNode("log", base_expr)
+        assert node.compute_cost() == base_expr.compute_cost() + 200
+
+    def test_unary_neg_cost(self):
+        base_expr = Expr(VarNode("x"))
+        node = UnaryNode("-", base_expr)
+        assert node.compute_cost() == base_expr.compute_cost() + 1
+
+    def test_unary_fabs_cost(self):
+        base_expr = Expr(VarNode("x"))
+        node = UnaryNode("fabs", base_expr)
+        assert node.compute_cost() == base_expr.compute_cost() + 1
+
+    def test_binary_div_cost(self):
+        a = Expr(VarNode("a"))
+        b = Expr(VarNode("b"))
+        node = BinaryNode("/", a, b)
+        assert node.compute_cost() == a.compute_cost() + b.compute_cost() + 10
+
+    def test_binary_add_cost(self):
+        a = Expr(VarNode("a"))
+        b = Expr(VarNode("b"))
+        node = BinaryNode("+", a, b)
+        assert node.compute_cost() == a.compute_cost() + b.compute_cost() + 1
+
+    def test_compute_cost_accumulates_over_nested_tree(self):
+        # sqrt(x) costs 20; log(sqrt(x)) costs 20 + 200 = 220
+        x = Expr(VarNode("x"))
+        sqrt_node = UnaryNode("sqrt", x)
+        sqrt_expr = Expr(sqrt_node)
+        log_node = UnaryNode("log", sqrt_expr)
+        assert log_node.compute_cost() == 220
+
+
+# ---------------------------------------------------------------------------
+# to_cpp() — C++ code generation strings for each node type
+# ---------------------------------------------------------------------------
+
+class TestToCpp:
+    def test_const_named(self):
+        assert ConstNode(name="c").to_cpp() == "c"
+
+    def test_const_value(self):
+        assert ConstNode(value=3.0).to_cpp() == "3.0"
+
+    def test_var(self):
+        assert VarNode("x").to_cpp() == "x"
+
+    def test_index_1d(self):
+        # arr_expr wraps VarNode("arr", shape=(5,))
+        arr_expr = Expr(VarNode("arr", shape=(5,)))
+        node = IndexNode(arr_expr, 2)
+        assert node.to_cpp() == "arr[2]"
+
+    def test_index_2d(self):
+        # arr_expr wraps VarNode("arr", shape=(3, 2))
+        arr_expr = Expr(VarNode("arr", shape=(3, 2)))
+        node = IndexNode(arr_expr, (1, 0))
+        assert node.to_cpp() == "arr(1, 0)"
+
+    def test_passive_node(self):
+        # inner_expr wraps VarNode("x")
+        inner_expr = Expr(VarNode("x"))
+        node = PassiveNode(inner_expr)
+        assert node.to_cpp() == "A2D::get_data(x)"
+
+    def test_unary_neg(self):
+        expr = Expr(VarNode("x"))
+        node = UnaryNode("-", expr)
+        assert node.to_cpp() == "-(x)"
+
+    def test_binary_add(self):
+        a = Expr(VarNode("a"))
+        b = Expr(VarNode("b"))
+        node = BinaryNode("+", a, b)
+        assert node.to_cpp() == "(a + b)"
+
+    def test_binary_pow(self):
+        a = Expr(VarNode("a"))
+        b = Expr(VarNode("b"))
+        node = BinaryNode("**", a, b)
+        assert node.to_cpp() == "A2D::pow(a, b)"
+
+    def test_binary_atan2(self):
+        a = Expr(VarNode("a"))
+        b = Expr(VarNode("b"))
+        node = BinaryNode("atan2", a, b)
+        assert node.to_cpp() == "A2D::atan2(a, b)"
+
+    def test_binary_min2(self):
+        a = Expr(VarNode("a"))
+        b = Expr(VarNode("b"))
+        node = BinaryNode("min2", a, b)
+        assert node.to_cpp() == "A2D::min2(a, b)"
+
+    def test_binary_max2(self):
+        a = Expr(VarNode("a"))
+        b = Expr(VarNode("b"))
+        node = BinaryNode("max2", a, b)
+        assert node.to_cpp() == "A2D::max2(a, b)"
+
+
+# ---------------------------------------------------------------------------
+# Expr arithmetic operators — zero-propagation shortcuts and operator overloads
+#
+# The Expr class short-circuits several operations when one operand is zero:
+#   zero + e  →  e          (no BinaryNode created)
+#   e + zero  →  e
+#   zero * e  →  zero const
+#   e * zero  →  zero const
+#   e - zero  →  e
+#   zero / d  →  zero const
+# All other combinations produce the expected BinaryNode or UnaryNode tree.
+# ---------------------------------------------------------------------------
+
+class TestExprArithmetic:
+    """Zero-propagation shortcuts and operator overloads on the Expr wrapper class."""
+
+    @pytest.fixture(autouse=True)
+    def _fixtures(self):
+        self.zero = Expr(ConstNode(value=0.0))
+        self.e = Expr(VarNode("x"))
+
+    # --- __add__ ---
+
+    def test_zero_plus_e_returns_non_zero_operand(self):
+        """zero + e → result is the non-zero operand (no BinaryNode wrapper)."""
+        result = self.zero + self.e
+        assert result.serialize() == self.e.serialize()
+
+    def test_e_plus_zero_returns_non_zero_operand(self):
+        """e + zero → result is the non-zero operand."""
+        result = self.e + self.zero
+        assert result.serialize() == self.e.serialize()
+
+    def test_nonzero_plus_nonzero_produces_binary_node(self):
+        """e + e (both non-zero) → BinaryNode('+', ...)."""
+        e2 = Expr(VarNode("y"))
+        result = self.e + e2
+        assert isinstance(result.node, BinaryNode)
+        assert result.node.op == "+"
+
+    # --- __mul__ ---
+
+    def test_zero_times_e_is_zero(self):
+        """zero * e → result.is_zero() is True."""
+        result = self.zero * self.e
+        assert result.is_zero() is True
+
+    def test_e_times_zero_is_zero(self):
+        """e * zero → result.is_zero() is True."""
+        result = self.e * self.zero
+        assert result.is_zero() is True
+
+    # --- __pow__ ---
+
+    def test_e_pow_zero_int_is_one(self):
+        """e ** 0 (integer 0) → result.is_zero() is False and to_cpp() == '1.0'."""
+        result = self.e ** 0
+        assert result.is_zero() is False
+        assert result.to_cpp() == "1.0"
+
+    # --- __neg__ ---
+
+    def test_neg_e_wraps_unary_minus(self):
+        """-e → result.node is a UnaryNode with op='-'."""
+        result = -self.e
+        assert isinstance(result.node, UnaryNode)
+        assert result.node.op == "-"
+
+    # --- __sub__ ---
+
+    def test_e_minus_zero_returns_non_zero_operand(self):
+        """e - zero → result is the non-zero operand."""
+        result = self.e - self.zero
+        assert result.serialize() == self.e.serialize()
+
+    def test_zero_minus_e_wraps_unary_minus(self):
+        """zero - e → result wraps UnaryNode('-', e)."""
+        result = self.zero - self.e
+        assert isinstance(result.node, UnaryNode)
+        assert result.node.op == "-"
+        assert result.node.expr.serialize() == self.e.serialize()
+
+    # --- __truediv__ ---
+
+    def test_zero_divided_by_d_is_zero(self):
+        """zero / d → result.is_zero() is True."""
+        d = Expr(VarNode("d"))
+        result = self.zero / d
+        assert result.is_zero() is True
+
+    # --- __radd__ ---
+
+    def test_radd_int_produces_binary_node(self):
+        """1 + e → BinaryNode('+', const_1, e)."""
+        result = 1 + self.e
+        assert isinstance(result.node, BinaryNode)
+        assert result.node.op == "+"
+        assert isinstance(result.node.left.node, ConstNode)
+        assert result.node.left.node.value == 1
+        assert result.node.right.serialize() == self.e.serialize()
+
+    # --- __rsub__ ---
+
+    def test_rsub_float_produces_binary_node(self):
+        """1.0 - e → BinaryNode('-', const_1.0, e)."""
+        result = 1.0 - self.e
+        assert isinstance(result.node, BinaryNode)
+        assert result.node.op == "-"
+        assert isinstance(result.node.left.node, ConstNode)
+        assert result.node.left.node.value == 1.0
+        assert result.node.right.serialize() == self.e.serialize()
+
+    # --- __rmul__ ---
+
+    def test_rmul_int_produces_binary_node(self):
+        """2 * e → BinaryNode('*', const_2, e)."""
+        result = 2 * self.e
+        assert isinstance(result.node, BinaryNode)
+        assert result.node.op == "*"
+        assert isinstance(result.node.left.node, ConstNode)
+        assert result.node.left.node.value == 2
+        assert result.node.right.serialize() == self.e.serialize()
+
+    # --- __rtruediv__ ---
+
+    def test_rtruediv_float_produces_binary_node(self):
+        """1.0 / e → BinaryNode('/', const_1.0, e)."""
+        result = 1.0 / self.e
+        assert isinstance(result.node, BinaryNode)
+        assert result.node.op == "/"
+        assert isinstance(result.node.left.node, ConstNode)
+        assert result.node.left.node.value == 1.0
+        assert result.node.right.serialize() == self.e.serialize()
+
+    def test_rtruediv_zero_numerator_is_zero(self):
+        """0.0 / e → result.is_zero() is True."""
+        result = 0.0 / self.e
+        assert result.is_zero() is True
+
+
+# ---------------------------------------------------------------------------
+# Expr.serialize() / Expr.deserialize() — round-trip fidelity
+#
+# Serialization converts an expression tree to a nested tuple structure.
+# Deserialization reconstructs the tree. The round-trip property requires
+# that deserialize(serialize(e)).serialize() == serialize(e) for any Expr e.
+# ---------------------------------------------------------------------------
+
+class TestExprRoundTrip:
+    """Expr serialize/deserialize round-trip: all node types and edge cases."""
+
+    def test_const_node_int_type_preserved(self):
+        """ConstNode(value=5, type=int) round-trips with type=int preserved."""
+        original = Expr(ConstNode(value=5, type=int))
+        deserialized = Expr.deserialize(original.serialize())
+        assert isinstance(deserialized.node, ConstNode)
+        assert deserialized.node.type is int
+        assert deserialized.node.value == 5
+
+    def test_var_node_active_false_preserved(self):
+        """VarNode('x', active=False) round-trips with active=False preserved."""
+        original = Expr(VarNode("x", active=False))
+        deserialized = Expr.deserialize(original.serialize())
+        assert isinstance(deserialized.node, VarNode)
+        assert deserialized.node.active is False
+        assert deserialized.node.name == "x"
+
+    def test_nested_expression_round_trip(self):
+        """(a + b) * c round-trips: double serialize equals single serialize."""
+        a = Expr(VarNode("a"))
+        b = Expr(VarNode("b"))
+        c = Expr(VarNode("c"))
+        expr = (a + b) * c
+        once = expr.serialize()
+        twice = Expr.deserialize(once).serialize()
+        assert twice == once
+
+    def test_index_node_2d_tuple_preserved(self):
+        """IndexNode with 2-D tuple index (1, 0) round-trips with index tuple preserved."""
+        arr = Expr(VarNode("arr", shape=(3, 2)))
+        original = Expr(IndexNode(arr, (1, 0)))
+        deserialized = Expr.deserialize(original.serialize())
+        assert isinstance(deserialized.node, IndexNode)
+        assert deserialized.node.index == (1, 0)
+
+    def test_unrecognized_op_returns_value_error(self):
+        """Expr.deserialize with unknown op returns a ValueError (does not raise)."""
+        result = Expr.deserialize(("unknown_op", "foo", "bar"))
+        assert isinstance(result, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_shape() — shape normalisation and validation
+#
+# Converts None, int, list, or tuple inputs to a canonical tuple form.
+# Raises TypeError for unsupported input types and ValueError for shapes
+# with more than two dimensions (amigo only supports 1-D and 2-D arrays).
+# ---------------------------------------------------------------------------
+
+from amigo.expressions import _normalize_shape
+
+
+class TestNormalizeShape:
+    """_normalize_shape: valid conversions and error cases."""
+
+    def test_none_returns_none(self):
+        assert _normalize_shape(None) is None
+
+    def test_int_returns_1d_tuple(self):
+        assert _normalize_shape(3) == (3,)
+
+    def test_list_returns_tuple(self):
+        assert _normalize_shape([2, 3]) == (2, 3)
+
+    def test_1d_tuple_unchanged(self):
+        assert _normalize_shape((4,)) == (4,)
+
+    def test_3d_tuple_raises_value_error(self):
+        with pytest.raises(ValueError):
+            _normalize_shape((1, 2, 3))
+
+    def test_float_raises_type_error(self):
+        with pytest.raises(TypeError):
+            _normalize_shape(3.14)

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -15,6 +15,7 @@ Test areas:
   - Expr.serialize() / Expr.deserialize(): round-trip fidelity for all node types
   - _normalize_shape(): shape normalisation and validation
 """
+
 import pytest
 from amigo.expressions import (
     Expr,
@@ -30,6 +31,7 @@ from amigo.expressions import (
 # ---------------------------------------------------------------------------
 # is_zero() — zero-value detection on each node type
 # ---------------------------------------------------------------------------
+
 
 class TestIsZero:
     def test_const_zero_int(self):
@@ -60,6 +62,7 @@ class TestIsZero:
 # is_active() — active/passive flag for each node type
 # ---------------------------------------------------------------------------
 
+
 class TestIsActive:
     def test_const_is_never_active(self):
         assert ConstNode(value=1.0).is_active() is False
@@ -87,6 +90,7 @@ class TestIsActive:
 # ---------------------------------------------------------------------------
 # compute_cost() — operation cost increments for each node type
 # ---------------------------------------------------------------------------
+
 
 class TestComputeCost:
     def test_const_cost_is_zero(self):
@@ -144,6 +148,7 @@ class TestComputeCost:
 # ---------------------------------------------------------------------------
 # to_cpp() — C++ code generation strings for each node type
 # ---------------------------------------------------------------------------
+
 
 class TestToCpp:
     def test_const_named(self):
@@ -222,6 +227,7 @@ class TestToCpp:
 # All other combinations produce the expected BinaryNode or UnaryNode tree.
 # ---------------------------------------------------------------------------
 
+
 class TestExprArithmetic:
     """Zero-propagation shortcuts and operator overloads on the Expr wrapper class."""
 
@@ -265,7 +271,7 @@ class TestExprArithmetic:
 
     def test_e_pow_zero_int_is_one(self):
         """e ** 0 (integer 0) → result.is_zero() is False and to_cpp() == '1.0'."""
-        result = self.e ** 0
+        result = self.e**0
         assert result.is_zero() is False
         assert result.to_cpp() == "1.0"
 
@@ -356,6 +362,7 @@ class TestExprArithmetic:
 # Deserialization reconstructs the tree. The round-trip property requires
 # that deserialize(serialize(e)).serialize() == serialize(e) for any Expr e.
 # ---------------------------------------------------------------------------
+
 
 class TestExprRoundTrip:
     """Expr serialize/deserialize round-trip: all node types and edge cases."""

--- a/tests/unit/test_model_helpers.py
+++ b/tests/unit/test_model_helpers.py
@@ -1,0 +1,105 @@
+"""
+Unit tests for pure-Python helpers in amigo/model.py.
+
+Covers GlobalIndexPool and the expression-string parser functions.
+The compiled C extension (amigo.amigo) is stubbed out by conftest.py so
+these tests run without a C++ build.
+
+Test areas:
+  - GlobalIndexPool.allocate(): returns correctly shaped numpy arrays with
+    contiguous, non-overlapping integer indices; counter advances after each call.
+  - _parse_var_expr(): parses dotted-path strings (with optional subscript
+    notation) into a (path_list, indices_tuple) pair.
+  - _parse_attribute_path(): converts an AST Attribute node into an ordered
+    list of name segments.
+"""
+import ast
+import pytest
+import numpy as np
+
+from amigo.model import GlobalIndexPool, _parse_var_expr, _parse_attribute_path
+
+
+# ---------------------------------------------------------------------------
+# GlobalIndexPool — contiguous, non-overlapping index allocation
+#
+# Each call to allocate(shape) returns a numpy array of the requested shape
+# filled with the next available integer indices. The pool's counter advances
+# by the total number of elements allocated.
+# ---------------------------------------------------------------------------
+
+class TestGlobalIndexPool:
+    """GlobalIndexPool: shape, values, non-overlapping ranges, and counter."""
+    def test_first_allocate_shape_and_values(self):
+        """First allocate((3,)) returns array of shape (3,) with values [0, 1, 2]."""
+        pool = GlobalIndexPool()
+        result = pool.allocate((3,))
+        assert result.shape == (3,)
+        np.testing.assert_array_equal(result, [0, 1, 2])
+
+    def test_successive_calls_non_overlapping(self):
+        """Successive allocations return non-overlapping index ranges."""
+        pool = GlobalIndexPool()
+        first = pool.allocate((3,))
+        second = pool.allocate((2,))
+        np.testing.assert_array_equal(first, [0, 1, 2])
+        np.testing.assert_array_equal(second, [3, 4])
+
+    def test_allocate_2d_shape(self):
+        """allocate((2, 3)) returns array of shape (2, 3)."""
+        pool = GlobalIndexPool()
+        result = pool.allocate((2, 3))
+        assert result.shape == (2, 3)
+
+    def test_counter_advances_after_each_allocation(self):
+        """Counter advances correctly after each allocation."""
+        pool = GlobalIndexPool()
+        assert pool.counter == 0
+        pool.allocate((3,))
+        assert pool.counter == 3
+        pool.allocate((2, 3))
+        assert pool.counter == 9  # 3 + 6
+
+
+# ---------------------------------------------------------------------------
+# _parse_var_expr / _parse_attribute_path — expression string parsing
+#
+# _parse_var_expr converts strings like "model.group.var" or
+# "model.group.var[:, 0]" into a (path_list, indices_tuple) pair.
+# _parse_attribute_path converts an AST Attribute node into an ordered
+# list of name segments (e.g. "a.b" → ["a", "b"]).
+# ---------------------------------------------------------------------------
+
+class TestParseVarExpr:
+    """_parse_var_expr: dotted paths, slice notation, and invalid input handling."""
+    def test_simple_attribute_path(self):
+        """'model.group.var' returns (['model', 'group', 'var'], None)."""
+        path, indices = _parse_var_expr("model.group.var")
+        assert path == ["model", "group", "var"]
+        assert indices is None
+
+    def test_full_slice(self):
+        """'model.group.var[:]' returns path and indices containing slice(None, None, None)."""
+        path, indices = _parse_var_expr("model.group.var[:]")
+        assert path == ["model", "group", "var"]
+        assert indices == (slice(None, None, None),)
+
+    def test_multi_index_slice_and_int(self):
+        """'model.group.var[:, 0]' returns indices (slice(None, None, None), 0)."""
+        path, indices = _parse_var_expr("model.group.var[:, 0]")
+        assert path == ["model", "group", "var"]
+        assert indices == (slice(None, None, None), 0)
+
+    def test_invalid_expression_raises_value_error(self):
+        """A string that is not a valid attribute or subscript expression raises ValueError."""
+        with pytest.raises(ValueError):
+            _parse_var_expr("not a valid expression!")
+
+
+class TestParseAttributePath:
+    """_parse_attribute_path: reconstructs ordered name segments from an AST node."""
+    def test_two_part_path(self):
+        """Parsing AST of 'a.b' and calling _parse_attribute_path returns ['a', 'b']."""
+        node = ast.parse("a.b", mode="eval").body
+        result = _parse_attribute_path(node)
+        assert result == ["a", "b"]

--- a/tests/unit/test_model_helpers.py
+++ b/tests/unit/test_model_helpers.py
@@ -13,6 +13,7 @@ Test areas:
   - _parse_attribute_path(): converts an AST Attribute node into an ordered
     list of name segments.
 """
+
 import ast
 import pytest
 import numpy as np
@@ -28,8 +29,10 @@ from amigo.model import GlobalIndexPool, _parse_var_expr, _parse_attribute_path
 # by the total number of elements allocated.
 # ---------------------------------------------------------------------------
 
+
 class TestGlobalIndexPool:
     """GlobalIndexPool: shape, values, non-overlapping ranges, and counter."""
+
     def test_first_allocate_shape_and_values(self):
         """First allocate((3,)) returns array of shape (3,) with values [0, 1, 2]."""
         pool = GlobalIndexPool()
@@ -70,8 +73,10 @@ class TestGlobalIndexPool:
 # list of name segments (e.g. "a.b" → ["a", "b"]).
 # ---------------------------------------------------------------------------
 
+
 class TestParseVarExpr:
     """_parse_var_expr: dotted paths, slice notation, and invalid input handling."""
+
     def test_simple_attribute_path(self):
         """'model.group.var' returns (['model', 'group', 'var'], None)."""
         path, indices = _parse_var_expr("model.group.var")
@@ -98,6 +103,7 @@ class TestParseVarExpr:
 
 class TestParseAttributePath:
     """_parse_attribute_path: reconstructs ordered name segments from an AST node."""
+
     def test_two_part_path(self):
         """Parsing AST of 'a.b' and calling _parse_attribute_path returns ['a', 'b']."""
         node = ast.parse("a.b", mode="eval").body


### PR DESCRIPTION
## Summary

Adds a comprehensive unit test suite covering four core modules. Tests are structured as class-based pytest suites with hand-crafted inputs, requiring no compiled C extension or solver to run.

**Modules covered:**

- **`amigo/block_detection.py`** — Tests for `_compute_degrees`, `_find_connected_components`, `_build_primal_adjacency`, and `detect_bfs_level_blocks`. Covers multiplier (dual) row exclusion, BFS connected component detection, and block classification into small blocks, BFS chains, and hub variables.
- **`amigo/component.py`** — Tests for `Meta` construction validation (rejects invalid names, bounds, values, and unknown kwargs), `Meta` serialization round-trips, and `InputSet`, `ConstantSet`, and `DataSet` container behavior.
- **`amigo/expressions.py`** — Tests for the `ExprNode` subclass hierarchy and `Expr` wrapper, covering `is_zero`, `is_active`, `compute_cost`, `to_cpp` code generation, arithmetic operator zero-propagation shortcuts, and `serialize`/`deserialize` round-trips.
- **`amigo/model.py`** — Tests for `GlobalIndexPool.allocate` (contiguous, non-overlapping index allocation), `_parse_var_expr` (dotted-path string parsing with subscript notation), and `_parse_attribute_path` (AST attribute node traversal). The compiled C extension is stubbed in `conftest.py` so these tests run without a C++ build.

**Infrastructure:**
- Added `tests/unit/__init__.py` and `tests/unit/conftest.py` (C extension stub)
- Enabled Windows CI for the new unit tests in `.github/workflows/pytest-windows.yml`