### PR TITLE
Implement trajectory component

### DIFF
--- a/amigo/__init__.py
+++ b/amigo/__init__.py
@@ -44,3 +44,9 @@ from .interfaces import (
     ExplicitOpenMDAOPostOptComponent,
     AmigoIndepVarComp,
 )
+from .trajectory import (
+    TrajectorySource,
+    TrajectoryComponent,
+    TrajectoryModel,
+    TrajModel,
+)

--- a/amigo/__init__.py
+++ b/amigo/__init__.py
@@ -44,9 +44,4 @@ from .interfaces import (
     ExplicitOpenMDAOPostOptComponent,
     AmigoIndepVarComp,
 )
-from .trajectory import (
-    TrajectorySource,
-    TrajectoryComponent,
-    TrajectoryModel,
-    TrajModel,
-)
+from .trajectory import *

--- a/amigo/component.py
+++ b/amigo/component.py
@@ -813,14 +813,8 @@ class Component:
         return out_shapes
 
     def _is_overridden(self, method_name):
-        instance_method = getattr(self, method_name)
-        base_method = getattr(type(self).__bases__[0], method_name, None)
-
-        # Unbind methods so we compare function objects directly
-        if isinstance(instance_method, types.MethodType):
-            instance_method = instance_method.__func__
-        if isinstance(base_method, types.MethodType):
-            base_method = base_method.__func__
+        instance_method = getattr(type(self), method_name, None)
+        base_method = getattr(Component, method_name, None)
 
         return instance_method is not base_method
 

--- a/amigo/trajectory.py
+++ b/amigo/trajectory.py
@@ -175,7 +175,45 @@ class TrajectoryModel:
 
 
 class TrajModel(am.Model):
+    """
+    Model to streamline continuous-time dynamics and trajectory computation.
+
+    Contains a `TrajectorySource` and `TrajectoryComponent` with automatic linking.
+
+    The `TrajectorySource` is labeled as `source` in this model. The `TrajectoryComponent`
+    is labeled as `kernel`.
+
+    Example Usage
+    -------
+    Consider a problem to minimize the final time.
+    Assume `dynamics` has been previously defined and has an auxiliary input `alpha`.
+    For brevity: setting lower/upper bounds, boundary conditions, etc. are not included.
+    ```
+    traj = am.TrajModel(dynamics)
+
+    model = am.Model("example")
+    model.add_model("traj", traj)
+
+    # Link to a BSpline that controls alpha
+    model.link("traj.source.alpha", "bspline.interp_values.alpha")
+
+    # Link final time from objective
+    model.link("obj.tf[0]", f"traj.kernel.tf[:]")
+    ```
+    """
+
     def __init__(self, dynamics: TrajectoryComponent, module_name: str | None = None):
+        """
+        Initialize a TrajectoryModel.
+
+        Args:
+            dynamics (TrajectoryComponent) : implements the governing dynamical equations
+            module_name (str) : specify name for the module (optional)
+
+        Note:
+        `TrajectorySource` is automatically created based on the input parameters to the
+        trajectory component.
+        """
         super().__init__(module_name)
 
         self._num_time_steps = dynamics.num_time_steps
@@ -201,8 +239,23 @@ class TrajModel(am.Model):
         return
 
     def link_boundary_conditions(
-        self, model, traj_name: str, ic: str = None, fc: str = None
+        self, model: am.Model, traj_name: str, ic: str = None, fc: str = None
     ):
+        """
+        Helper utility to set boundary conditions.
+
+        Args:
+            model (am.Model) : parent model that `TrajModel` belongs to
+            traj_name (str) : name of the `TrajModel` in `model`
+            ic (str) : name of the initial condition
+            fc (str) : name of the final condition
+
+        Effectively replaces the following links:
+        ```
+        model.link("traj.source.q[0,:]", "ic.q[0,:]")
+        model.link("traj.source.q[num_time_steps,:]", "fc.q[0,:]")
+        ```
+        """
         if ic:
             model.link(f"{traj_name}.source.q[0,:]", f"{ic}.q[0,:]")
         if fc:

--- a/amigo/trajectory.py
+++ b/amigo/trajectory.py
@@ -1,0 +1,211 @@
+import numpy as np
+import amigo as am
+from abc import abstractmethod
+
+
+class TrajectorySource(am.Component):
+    def __init__(self, state_size: int, inputs: list[dict] = []):
+        super().__init__()
+
+        self.add_input("q", shape=state_size)
+
+        for input in inputs:
+            name = input["name"]
+            self.add_input(
+                f"{name}", shape=input.get("shape"), label=input.get("label")
+            )
+
+        return
+
+
+class TrajectoryComponent(am.Component):
+    """
+    Component wrapper designed for trajectory computations using the trapezoid rule.
+
+    The user defines the `_dynamics` method to implement the dynamics governing equations.
+    The `compute` method automatically calls the dynamics based on any specified inputs
+    (the state `q` is always assumed).
+
+    Note:
+    Can be paired with TrajectorySource either directly by the user or automatically if used
+    to create a TrajectoryModel.
+
+    Example Usage:
+    ---------
+    For a trajectory calculated at 20 points in time and a state vector of dimension 4,
+    we also include two extra inputs: angle of attack and throttle. A scaling dictionary
+    is also provided in this example.
+    ```
+    class ExampleDynamics(am.TrajectoryComponent):
+        def __init__(self, scaling):
+            super().__init__(20, 4, [{"name": "alpha"}, {"name": "throttle"}])
+
+            self.scaling = scaling
+            self.add_constant("g", value=9.81)
+            return
+
+        def _dynamics(self, q, alpha, throttle):
+            g = self.constants["g"]
+            mass = q[0] * self.scaling["mass"]
+            ...
+            return qdot
+
+        def compute(self):
+            super().compute()
+    ```
+    """
+
+    def __init__(
+        self, num_time_steps: int, state_size: int, aux_inputs: list[dict] = []
+    ):
+        """
+        Automatically adds inputs for the state variables and final time, as well as
+        any additional inputs specified in `aux_inputs`.
+
+        The user can specify constants after calling `super().__init__()`
+
+        Args:
+            num_time_steps (int) : Number of evaluation points in the trajectory
+            state_size (int) : Size of the state vector at a given point
+            aux_inputs : list of auxiliary inputs besides the state vector `q`
+
+        Inputs must be specified as a list of dictionaries, with a dictionary for every
+        auxiliary input that contains at least the "name" entry.
+        ```
+        """
+        super().__init__()
+
+        self._input_names = [input["name"] for input in aux_inputs]
+        self.num_time_steps = num_time_steps
+        self._state_size = state_size
+        self._input_list = aux_inputs
+
+        self.add_input("tf", label="final time")
+        self.add_input("q1", shape=state_size)
+        self.add_input("q2", shape=state_size)
+
+        for input in aux_inputs:
+            name = input["name"]
+            self.add_input(
+                f"{name}1", shape=input.get("shape"), label=input.get("label")
+            )
+            self.add_input(
+                f"{name}2", shape=input.get("shape"), label=input.get("label")
+            )
+
+        self.add_constraint("res", shape=state_size)
+
+        return
+
+    @abstractmethod
+    def _dynamics(self, q, *args):
+        """
+        User must implement the dynamics and return qdot.
+
+        Args:
+            q : State vector
+
+        Optional additional arguments must be specified in the same order as defined in `aux_inputs`.
+        """
+        pass
+
+    def compute(self):
+        """
+        User must define their own `compute` method that calls `super().compute()`
+        """
+        dt = self.inputs["tf"] / self.num_time_steps
+        input1_vars = [self.inputs[f"{name}1"] for name in self._input_names]
+        input2_vars = [self.inputs[f"{name}2"] for name in self._input_names]
+
+        q1, q2 = self.inputs["q1"], self.inputs["q2"]
+
+        f1 = self._dynamics(q1, *input1_vars)
+        f2 = self._dynamics(q2, *input2_vars)
+        self.constraints["res"] = [
+            q2[i] - q1[i] - 0.5 * dt * (f1[i] + f2[i]) for i in range(self._state_size)
+        ]
+
+        return
+
+
+class TrajectoryModel:
+
+    def __init__(
+        self, num_time_steps: int, state_size: int, aux_inputs: list[dict] = []
+    ):
+        self.num_time_steps = num_time_steps
+        self.state_size = state_size
+        self._input_list = aux_inputs
+        self._input_names = [input["name"] for input in aux_inputs]
+
+        return
+
+    def create_model(
+        self,
+        dynamics: TrajectoryComponent,
+        module_name: str | None = None,
+    ):
+        model = am.Model(module_name)
+
+        model.add_component(
+            "source",
+            self.num_time_steps + 1,
+            TrajectorySource(self.state_size, self._input_list),
+        )
+        model.add_component("kernel", self.num_time_steps, dynamics)
+
+        model.link(f"source.q[:-1,:]", f"kernel.q1")
+        model.link(f"source.q[1:,:]", f"kernel.q2")
+
+        for name in self._input_names:
+            model.link(f"source.{name}[:-1]", f"kernel.{name}1")
+            model.link(f"source.{name}[1:]", f"kernel.{name}2")
+
+        return model
+
+    def link_boundary_conditions(
+        self, model: am.Model, traj_model_name: str, ic: str = None, fc: str = None
+    ):
+        if ic:
+            model.link(f"{traj_model_name}.source.q[0,:]", f"{ic}.q[0,:]")
+        if fc:
+            model.link(
+                f"{traj_model_name}.source.q[{self.num_time_steps}, :]", f"{fc}.q[0,:]"
+            )
+
+
+class TrajModel(am.Model):
+    def __init__(self, dynamics: TrajectoryComponent, module_name: str | None = None):
+        super().__init__(module_name)
+
+        self._num_time_steps = dynamics.num_time_steps
+        self._state_size = dynamics._state_size
+        input_list = dynamics._input_list
+        input_names = dynamics._input_names
+
+        self.add_component(
+            "source",
+            self._num_time_steps + 1,
+            TrajectorySource(self._state_size, input_list),
+        )
+
+        self.add_component("kernel", self._num_time_steps, dynamics)
+
+        self.link(f"source.q[:-1,:]", f"kernel.q1")
+        self.link(f"source.q[1:,:]", f"kernel.q2")
+
+        for name in input_names:
+            self.link(f"source.{name}[:-1]", f"kernel.{name}1")
+            self.link(f"source.{name}[1:]", f"kernel.{name}2")
+
+        return
+
+    def link_boundary_conditions(
+        self, model, traj_name: str, ic: str = None, fc: str = None
+    ):
+        if ic:
+            model.link(f"{traj_name}.source.q[0,:]", f"{ic}.q[0,:]")
+        if fc:
+            model.link(
+                f"{traj_name}.source.q[{self._num_time_steps}, :]", f"{fc}.q[0,:]"
+            )

--- a/amigo/trajectory.py
+++ b/amigo/trajectory.py
@@ -22,7 +22,7 @@ class TrajectoryComponent(am.Component):
     """
     Component wrapper designed for trajectory computations using the trapezoid rule.
 
-    The user defines the `_dynamics` method to implement the dynamics governing equations.
+    The user defines the `dynamics` method to implement the dynamics governing equations.
     The `compute` method automatically calls the dynamics based on any specified inputs
     (the state `q` is always assumed).
 
@@ -44,14 +44,11 @@ class TrajectoryComponent(am.Component):
             self.add_constant("g", value=9.81)
             return
 
-        def _dynamics(self, q, alpha, throttle):
+        def dynamics(self, q, alpha, throttle):
             g = self.constants["g"]
             mass = q[0] * self.scaling["mass"]
             ...
             return qdot
-
-        def compute(self):
-            super().compute()
     ```
     """
 
@@ -98,7 +95,7 @@ class TrajectoryComponent(am.Component):
         return
 
     @abstractmethod
-    def _dynamics(self, q, *args):
+    def dynamics(self, q, *args):
         """
         User must implement the dynamics and return qdot.
 
@@ -111,7 +108,7 @@ class TrajectoryComponent(am.Component):
 
     def compute(self):
         """
-        User must define their own `compute` method that calls `super().compute()`
+        The user-defined dynamics are used to compute constraints.
         """
         dt = self.inputs["tf"] / self.num_time_steps
         input1_vars = [self.inputs[f"{name}1"] for name in self._input_names]
@@ -119,8 +116,8 @@ class TrajectoryComponent(am.Component):
 
         q1, q2 = self.inputs["q1"], self.inputs["q2"]
 
-        f1 = self._dynamics(q1, *input1_vars)
-        f2 = self._dynamics(q2, *input2_vars)
+        f1 = self.dynamics(q1, *input1_vars)
+        f2 = self.dynamics(q2, *input2_vars)
         self.constraints["res"] = [
             q2[i] - q1[i] - 0.5 * dt * (f1[i] + f2[i]) for i in range(self._state_size)
         ]

--- a/amigo/trajectory/__init__.py
+++ b/amigo/trajectory/__init__.py
@@ -1,3 +1,3 @@
 from .trajectory import TrajectorySource, TrajectoryComponent, TrajectoryModel
 
-__all__ = [TrajectorySource, TrajectoryComponent, TrajectoryModel]
+# __all__ = [TrajectorySource, TrajectoryComponent, TrajectoryModel]

--- a/amigo/trajectory/__init__.py
+++ b/amigo/trajectory/__init__.py
@@ -1,0 +1,3 @@
+from .trajectory import TrajectorySource, TrajectoryComponent, TrajectoryModel
+
+__all__ = [TrajectorySource, TrajectoryComponent, TrajectoryModel]

--- a/amigo/trajectory/trajectory.py
+++ b/amigo/trajectory/trajectory.py
@@ -75,7 +75,7 @@ class TrajectoryComponent(am.Component):
         self._input_names = [input["name"] for input in aux_inputs]
         self.num_time_steps = num_time_steps
         self._state_size = state_size
-        self._input_list = aux_inputs
+        self._aux_inputs = aux_inputs
 
         self.add_input("tf", label="final time")
         self.add_input("q1", shape=state_size)
@@ -126,22 +126,65 @@ class TrajectoryComponent(am.Component):
 
 
 class TrajectoryModel:
+    """
+    Model helper to streamline continuous-time dynamics and trajectory computation.
+
+    Contains a `TrajectorySource` and `TrajectoryComponent` with automatic linking.
+
+    The `TrajectorySource` is labeled as `source` in this model. The `TrajectoryComponent`
+    is labeled as `kernel`.
+
+    Example Usage
+    -------
+    Consider a problem to minimize the final time.
+    Assume `dynamics` has been previously defined and has an auxiliary input `alpha`.
+    For brevity: setting lower/upper bounds, boundary conditions, etc. are not included.
+    ```
+    traj = am.TrajectoryModel(dynamics)
+
+    model = am.Model("example")
+    model.add_model("traj", traj.create_model())
+
+    # Link to a BSpline that controls alpha
+    model.link("traj.source.alpha", "bspline.interp_values.alpha")
+
+    # Link final time from objective
+    model.link("obj.tf[0]", f"traj.kernel.tf[:]")
+    ```
+    """
 
     def __init__(
-        self, num_time_steps: int, state_size: int, aux_inputs: list[dict] = []
+        self,
+        dynamics: TrajectoryComponent,
     ):
-        self.num_time_steps = num_time_steps
-        self.state_size = state_size
-        self._input_list = aux_inputs
-        self._input_names = [input["name"] for input in aux_inputs]
+        """
+        Initialize a TrajectoryModel helper.
+
+        Args:
+            dynamics (TrajectoryComponent) : implements the governing dynamical equations
+
+        Note:
+        `TrajectorySource` is automatically created based on the input parameters to the
+        trajectory component.
+        """
+        self._dynamics = dynamics
+        self.num_time_steps = dynamics.num_time_steps
+        self.state_size = dynamics._state_size
+        self._input_list = dynamics._aux_inputs
+        self._input_names = [input["name"] for input in self._input_list]
 
         return
 
     def create_model(
         self,
-        dynamics: TrajectoryComponent,
         module_name: str | None = None,
     ):
+        """
+        Create and link the Amigo model
+
+        Args:
+            module_name (str) : specify name for the module (optional)
+        """
         model = am.Model(module_name)
 
         model.add_component(
@@ -149,7 +192,7 @@ class TrajectoryModel:
             self.num_time_steps + 1,
             TrajectorySource(self.state_size, self._input_list),
         )
-        model.add_component("kernel", self.num_time_steps, dynamics)
+        model.add_component("kernel", self.num_time_steps, self._dynamics)
 
         model.link(f"source.q[:-1,:]", f"kernel.q1")
         model.link(f"source.q[1:,:]", f"kernel.q2")
@@ -163,87 +206,12 @@ class TrajectoryModel:
     def link_boundary_conditions(
         self, model: am.Model, traj_model_name: str, ic: str = None, fc: str = None
     ):
-        if ic:
-            model.link(f"{traj_model_name}.source.q[0,:]", f"{ic}.q[0,:]")
-        if fc:
-            model.link(
-                f"{traj_model_name}.source.q[{self.num_time_steps}, :]", f"{fc}.q[0,:]"
-            )
-
-
-class TrajModel(am.Model):
-    """
-    Model to streamline continuous-time dynamics and trajectory computation.
-
-    Contains a `TrajectorySource` and `TrajectoryComponent` with automatic linking.
-
-    The `TrajectorySource` is labeled as `source` in this model. The `TrajectoryComponent`
-    is labeled as `kernel`.
-
-    Example Usage
-    -------
-    Consider a problem to minimize the final time.
-    Assume `dynamics` has been previously defined and has an auxiliary input `alpha`.
-    For brevity: setting lower/upper bounds, boundary conditions, etc. are not included.
-    ```
-    traj = am.TrajModel(dynamics)
-
-    model = am.Model("example")
-    model.add_model("traj", traj)
-
-    # Link to a BSpline that controls alpha
-    model.link("traj.source.alpha", "bspline.interp_values.alpha")
-
-    # Link final time from objective
-    model.link("obj.tf[0]", f"traj.kernel.tf[:]")
-    ```
-    """
-
-    def __init__(self, dynamics: TrajectoryComponent, module_name: str | None = None):
-        """
-        Initialize a TrajectoryModel.
-
-        Args:
-            dynamics (TrajectoryComponent) : implements the governing dynamical equations
-            module_name (str) : specify name for the module (optional)
-
-        Note:
-        `TrajectorySource` is automatically created based on the input parameters to the
-        trajectory component.
-        """
-        super().__init__(module_name)
-
-        self._num_time_steps = dynamics.num_time_steps
-        self._state_size = dynamics._state_size
-        input_list = dynamics._input_list
-        input_names = dynamics._input_names
-
-        self.add_component(
-            "source",
-            self._num_time_steps + 1,
-            TrajectorySource(self._state_size, input_list),
-        )
-
-        self.add_component("kernel", self._num_time_steps, dynamics)
-
-        self.link(f"source.q[:-1,:]", f"kernel.q1")
-        self.link(f"source.q[1:,:]", f"kernel.q2")
-
-        for name in input_names:
-            self.link(f"source.{name}[:-1]", f"kernel.{name}1")
-            self.link(f"source.{name}[1:]", f"kernel.{name}2")
-
-        return
-
-    def link_boundary_conditions(
-        self, model: am.Model, traj_name: str, ic: str = None, fc: str = None
-    ):
         """
         Helper utility to set boundary conditions.
 
         Args:
-            model (am.Model) : parent model that `TrajModel` belongs to
-            traj_name (str) : name of the `TrajModel` in `model`
+            model (am.Model) : parent model that `TrajectoryModel` belongs to
+            traj_name (str) : name of the `TrajectoryModel` in `model`
             ic (str) : name of the initial condition
             fc (str) : name of the final condition
 
@@ -254,8 +222,8 @@ class TrajModel(am.Model):
         ```
         """
         if ic:
-            model.link(f"{traj_name}.source.q[0,:]", f"{ic}.q[0,:]")
+            model.link(f"{traj_model_name}.source.q[0,:]", f"{ic}.q[0,:]")
         if fc:
             model.link(
-                f"{traj_name}.source.q[{self._num_time_steps}, :]", f"{fc}.q[0,:]"
+                f"{traj_model_name}.source.q[{self.num_time_steps}, :]", f"{fc}.q[0,:]"
             )

--- a/examples/time_to_climb/time_to_climb_traj.py
+++ b/examples/time_to_climb/time_to_climb_traj.py
@@ -1,0 +1,344 @@
+import amigo as am
+from amigo.interp import BSpline
+import numpy as np
+import sys, os
+import matplotlib.pylab as plt
+import niceplots
+import argparse
+import json
+
+# Problem parameters
+num_time_steps = 500
+
+"""
+Min Time to Climb 
+==============================
+
+This example is from Betts' book "Practical Methods for Optimal Control
+Using NonlinearProgramming", 3rd edition, Chapter 10: Test Problems.
+
+This is a non-scaled problem with a single component dynamics code
+"""
+
+
+class AircraftDynamics(am.TrajectoryComponent):
+    def __init__(self, scaling):
+        # super().__init__() will automatically create the inputs and constraint
+        super().__init__(num_time_steps, state_size=5, aux_inputs=[{"name": "alpha"}])
+
+        self.scaling = scaling
+
+        # Physical constants matching the original code
+        self.add_constant("S", value=49.2386)  # m^2
+        self.add_constant("CL_alpha", value=3.44)
+        self.add_constant("CD0", value=0.013)
+        self.add_constant("kappa", value=0.54)
+        self.add_constant("Isp", value=1600.0)  # s
+        self.add_constant("TtoW", value=0.9)
+        self.add_constant("m0", value=19030.0)  # kg
+        self.add_constant("gamma_air", value=1.4)
+        self.add_constant("R", value=287.058)
+        self.add_constant("g", value=9.81)
+        self.add_constant("conv", value=np.pi / 180.0)
+
+        return
+
+    def _dynamics(self, q, alpha):
+        # Get constants
+        S = self.constants["S"]
+        CL_alpha = self.constants["CL_alpha"]
+        CD0 = self.constants["CD0"]
+        kappa = self.constants["kappa"]
+        Isp = self.constants["Isp"]
+        TtoW = self.constants["TtoW"]
+        m0 = self.constants["m0"]
+        g = self.constants["g"]
+        conv = self.constants["conv"]
+
+        # State variables
+        v = 100.0 * q[0]  # Convert velocity to [m/s]
+        gamma = q[1]  # flight path angle [degrees]
+        m = 1000.0 * q[4]  # Convert mass to [kg]
+
+        # Atmospheric properties (simplified)
+        T_atm = 288.15  # K
+        h_m = q[2] * self.scaling["altitude"]
+        rho = 1.225 * am.exp(-h_m / 8500.0)  # kg/m^3
+
+        # Aerodynamics matching original code
+        CL = CL_alpha * conv * alpha  # Convert alpha from degrees to radians
+
+        # Drag coefficient (simplified - no compressibility for now)
+        CD = CD0 + kappa * CL**2
+
+        # Dynamic pressure and forces
+        qinfty = 0.5 * rho * v**2
+        D = qinfty * S * CD
+        L = qinfty * S * CL
+
+        # Thrust
+        T = TtoW * m0 * g
+
+        # Convert angles to radians for dynamics
+        alpha_rad = conv * alpha
+        gamma_rad = conv * gamma
+
+        # Set intermediate varaibles
+        sin_alpha = am.sin(alpha_rad)
+        cos_alpha = am.cos(alpha_rad)
+        sin_gamma = am.sin(gamma_rad)
+        cos_gamma = am.cos(gamma_rad)
+
+        # Aircraft dynamics equations (matching original computeSystemResidual)
+        qdot = [
+            ((T / m) * cos_alpha - (D / m) - g * sin_gamma) / self.scaling["velocity"],
+            ((T / (m * v) * sin_alpha + (L / (m * v)) - (g / v) * cos_gamma)) / conv,
+            v * sin_gamma / self.scaling["altitude"],
+            v * cos_gamma / self.scaling["range"],
+            -(T / (g * Isp)) / self.scaling["mass"],
+        ]
+
+        return qdot
+
+    def compute(self):
+        super().compute()
+
+
+class Objective(am.Component):
+    def __init__(self):
+        super().__init__()
+
+        self.add_input("tf", label="final time")
+        self.add_objective("obj")
+
+        return
+
+    def compute(self):
+        tf = self.inputs["tf"]
+        self.objective["obj"] = tf  # Minimize final time
+
+        return
+
+
+class InitialConditions(am.Component):
+    def __init__(self, scaling):
+        super().__init__()
+        self.scaling = scaling
+        self.add_input("q", shape=5)
+        self.add_constraint("res", shape=5)
+
+    def compute(self):
+        q = self.inputs["q"]
+
+        # Initial conditions matching original getInitConditions
+        self.constraints["res"] = [
+            q[0] - 136.0 / self.scaling["velocity"],  # 136 [m/s]
+            q[1] - 0.0,  # flight path angle [degrees]
+            q[2] - 100.0 / self.scaling["altitude"],  # 100.0 [m]
+            q[3] - 0.0 / self.scaling["range"],  # [m]
+            q[4] - 19030.0 / self.scaling["mass"],  # 19030 [kg]
+        ]
+
+
+class FinalConditions(am.Component):
+    def __init__(self, scaling):
+        super().__init__()
+        self.scaling = scaling
+        self.add_input("q", shape=5)
+        self.add_constraint("res", shape=3)
+
+    def compute(self):
+        q = self.inputs["q"]
+        self.constraints["res"] = [
+            q[0] - 340.0 / self.scaling["velocity"],  # 340 [m/s]
+            q[1] - 0.0,  # Final flight path angle [degrees]
+            q[2] - 20000.0 / self.scaling["altitude"],  # 20 [km]
+        ]
+
+
+def plot_results(t, q, alpha):
+    """Plot the optimization results"""
+
+    with plt.style.context(niceplots.get_style()):
+        fig, axes = plt.subplots(3, 2, figsize=(12, 10))
+
+        # State variables
+        axes[0, 0].plot(t, 100 * q[:, 0])
+        axes[0, 0].set_ylabel("Velocity (m/s)")
+        axes[0, 0].set_xlabel("Time (s)")
+        axes[0, 0].grid(True)
+
+        axes[0, 1].plot(t, q[:, 1])
+        axes[0, 1].set_ylabel("Flight path angle (deg)")
+        axes[0, 1].set_xlabel("Time (s)")
+        axes[0, 1].grid(True)
+
+        axes[1, 0].plot(t, q[:, 2])
+        axes[1, 0].set_ylabel("Altitude (km)")
+        axes[1, 0].set_xlabel("Time (s)")
+        axes[1, 0].grid(True)
+
+        axes[1, 1].plot(t, q[:, 3])
+        axes[1, 1].set_ylabel("Range (km)")
+        axes[1, 1].set_xlabel("Time (s)")
+        axes[1, 1].grid(True)
+
+        axes[2, 0].plot(t, 1000 * q[:, 4])
+        axes[2, 0].set_ylabel("Mass (kg)")
+        axes[2, 0].set_xlabel("Time (s)")
+        axes[2, 0].grid(True)
+
+        axes[2, 1].plot(t, alpha)
+        axes[2, 1].set_ylabel("Angle of attack (deg)")
+        axes[2, 1].set_xlabel("Time (s)")
+        axes[2, 1].grid(True)
+
+        plt.tight_layout()
+        plt.savefig("time_to_climb_results.png", dpi=300, bbox_inches="tight")
+        plt.show()
+
+
+# Command line argument parsing
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--build", dest="build", action="store_true", default=False, help="Enable building"
+)
+args = parser.parse_args()
+
+# Set the scaling
+scaling = {"velocity": 100.0, "altitude": 1000.0, "range": 1000.0, "mass": 1000.0}
+
+# Create component instances
+ac = AircraftDynamics(scaling)
+obj = Objective()
+ic = InitialConditions(scaling)
+fc = FinalConditions(scaling)
+# TrajModel creates a submodel that links the dynamics and an automatic trajectory source
+traj = am.TrajModel(ac)
+
+# Number of bspline control points
+nctrl = 10
+
+# Interpolate from the x control points to the angle of attack
+bspline = BSpline(
+    input_name="x",
+    output_name="alpha",
+    num_interp_points=(num_time_steps + 1),
+    num_ctrl_points=nctrl,
+)
+
+# Create the model
+module_name = "time_to_climb"
+model = am.Model(module_name)
+
+# Add components to the model
+model.add_model("bspline", bspline.create_model())
+model.add_component("obj", 1, obj)
+model.add_component("ic", 1, ic)
+model.add_component("fc", 1, fc)
+# Instead of adding the dynamics and trapezoid integration separately, add the submodel
+model.add_model("traj", traj)
+
+# Link the alpha values - ac.alpha to bspline output
+model.link("traj.source.alpha", "bspline.interp_values.alpha")
+
+# Link final time from objective to all trapezoidal rule components
+model.link("obj.tf[0]", f"traj.kernel.tf[:]")
+
+# Link boundary conditions using new utility
+traj.link_boundary_conditions(model, "traj", "ic", "fc")
+
+# Build the module if requested
+if args.build:
+    model.build_module()
+
+# Initialize the model
+model.initialize()
+
+print(f"Num variables:              {model.num_variables}")
+print(f"Num constraints:            {model.num_constraints}")
+
+# Create the design vector
+x = model.create_vector()
+
+# Default to zero design variable values
+x[:] = 0.0
+
+# Set initial guess for final time
+tf_guess = 200.0
+x["obj.tf"] = tf_guess
+
+# Set initial guess for states (reasonable trajectory)
+t_guess = np.linspace(0, tf_guess, num_time_steps + 1)
+
+# Set the initial guess
+x["traj.source.q[:, 0]"] = 1.36 + (3.40 - 1.36) * t_guess / tf_guess  # velocity
+x["traj.source.q[:, 1]"] = 5.0 * np.sin(np.pi * t_guess / tf_guess)  # flight path angle
+x["traj.source.q[:, 2]"] = 1.0 + (20.0 - 1.0) * t_guess / tf_guess  # altitude
+x["traj.source.q[:, 3]"] = 1.36 * t_guess  # range
+x["traj.source.q[:, 4]"] = 19.03 - 0.2 * t_guess / tf_guess  # mass decrease
+
+# Set initial guess for control (constant small angle)
+x["traj.source.alpha"] = 1.0
+
+# Set up bounds
+lower = model.create_vector()
+upper = model.create_vector()
+
+# Final time bounds
+lower["obj.tf"] = 1.0
+upper["obj.tf"] = float("inf")
+
+# Control bounds (matching original -5 to 5 degrees)
+lower["traj.source.alpha"] = -float("inf")
+upper["traj.source.alpha"] = float("inf")
+
+# Unconstrain the state bounds by default
+lower["traj.source.q"] = -float("inf")
+upper["traj.source.q"] = float("inf")
+
+# State bounds for the flight path angle
+lower["traj.source.q[:, 1]"] = -90.0
+upper["traj.source.q[:, 1]"] = 90.0
+
+# State bounds for the altitude
+lower["traj.source.q[:, 2]"] = 0.0
+upper["traj.source.q[:, 2]"] = 25.0
+
+# Set the anlge of attack between an lower and an upper bound
+lower["bspline.control_points.x"] = -25.0
+upper["bspline.control_points.x"] = 25.0
+
+# Optimize
+opt = am.Optimizer(model, x, lower=lower, upper=upper, solver="mumps")
+data = opt.optimize(
+    {
+        "initial_barrier_param": 1.0,
+        "monotone_barrier_fraction": 0.25,
+        "barrier_strategy": "monotone",
+        "convergence_tolerance": 1e-10,
+        "max_line_search_iterations": 5,
+        "max_iterations": 1000,
+        "init_affine_step_multipliers": False,
+    }
+)
+
+# Save optimization data
+with open("time_to_climb_opt_data.json", "w") as fp:
+    json.dump(data, fp, indent=2)
+
+# Extract results
+tf_opt = x["obj.tf"][0]  # Extract scalar from array
+q = x["traj.source.q"]
+alpha = x["traj.source.alpha"]
+t = np.linspace(0, tf_opt, num_time_steps + 1)
+
+# Print the optimized results
+print(f"\nOptimization Results:")
+print(f"Optimal time:   {tf_opt:.2f} seconds")
+print(f"Final altitude: {q[-1, 2]:.0f} m")
+print(f"Final velocity: {q[-1, 0]:.1f} m/s")
+print(f"Final mass:     {q[-1, 4]:.0f} kg")
+
+# Plot results
+plot_results(t, q, alpha)

--- a/examples/time_to_climb/time_to_climb_traj.py
+++ b/examples/time_to_climb/time_to_climb_traj.py
@@ -210,8 +210,8 @@ ac = AircraftDynamics(scaling)
 obj = Objective()
 ic = InitialConditions(scaling)
 fc = FinalConditions(scaling)
-# TrajModel creates a submodel that links the dynamics and an automatic trajectory source
-traj = am.TrajModel(ac)
+# TrajectoryModel creates a submodel that links the dynamics and an automatic trajectory source
+traj = am.TrajectoryModel(ac)
 
 # Number of bspline control points
 nctrl = 10
@@ -234,7 +234,7 @@ model.add_component("obj", 1, obj)
 model.add_component("ic", 1, ic)
 model.add_component("fc", 1, fc)
 # Instead of adding the dynamics and trapezoid integration separately, add the submodel
-model.add_model("traj", traj)
+model.add_model("traj", traj.create_model())
 
 # Link the alpha values - ac.alpha to bspline output
 model.link("traj.source.alpha", "bspline.interp_values.alpha")

--- a/examples/time_to_climb/time_to_climb_traj.py
+++ b/examples/time_to_climb/time_to_climb_traj.py
@@ -43,7 +43,7 @@ class AircraftDynamics(am.TrajectoryComponent):
 
         return
 
-    def _dynamics(self, q, alpha):
+    def dynamics(self, q, alpha):
         # Get constants
         S = self.constants["S"]
         CL_alpha = self.constants["CL_alpha"]
@@ -99,9 +99,6 @@ class AircraftDynamics(am.TrajectoryComponent):
         ]
 
         return qdot
-
-    def compute(self):
-        super().compute()
 
 
 class Objective(am.Component):


### PR DESCRIPTION
## Summary

This PR introduces a `TrajectoryComponent` base class and `TrajModel` helper that streamline trajectory optimization problems in Amigo. Users can now define continuous-time dynamics in a single `_dynamics` method and let the framework handle time integration, state/derivative wiring, and boundary condition linking automatically.

## Motivation

Previously, setting up a trajectory optimization problem required significant boilerplate:

- A manual `TrapezoidRule` component (or similar) had to be written and added to the model
- The state variables (`q`) and their derivatives (`qdot`) had to be wired explicitly between the dynamics component and the integration component for each state dimension — a loop of `model.link` calls that is error-prone and tedious
- State sizes and time step counts had to be tracked and passed consistently across multiple components

## New API

### `TrajectoryComponent`

Dynamics components now inherit from `am.TrajectoryComponent` instead of `am.Component`. The constructor accepts `num_time_steps`, `state_size`, and an optional list of auxiliary inputs (e.g., control variables like angle of attack). Users implement a `_dynamics(self, q, *aux_inputs)` method that returns `qdot` as a list — the continuous-time right-hand side — and call `super().compute()` to invoke the integration logic.

### `TrajModel`

`am.TrajModel(component)` wraps a `TrajectoryComponent` into a self-contained submodel that includes an automatically constructed trapezoidal integration kernel and a source component holding the state variables and auxiliary inputs. This replaces the separate `TrapezoidRule` + dynamics component pattern.

### `traj.link_boundary_conditions`

A convenience method replaces manual `model.link` calls for initial and final condition components.

## Before / After Comparison

**Before** (`time_to_climb.py`):
- `TrapezoidRule` class manually implemented (~15 lines)
- `AircraftDynamics` inherits from `am.Component`, takes `q` and `qdot` as inputs, manually assembles residuals with trapezoidal terms baked in
- 6 components added individually to the model
- A `for i in range(5)` loop with 4 `model.link` calls per state to wire `q1`, `q2`, `q1dot`, `q2dot`
- Manual link for `tf` to every trap instance
- Manual links for initial/final boundary conditions

**After** (`time_to_climb_traj.py`):
- No `TrapezoidRule` class needed
- `AircraftDynamics` inherits from `am.TrajectoryComponent`; `_dynamics` returns `qdot` directly as continuous-time rates — no residual formulation required
- `am.TrajModel(ac)` constructs the integrated trajectory submodel in one line
- All state/derivative wiring is handled internally
- `traj.link_boundary_conditions(model, "traj", "ic", "fc")` replaces manual IC/FC links
- Reduced number of variables (no `qdot` inputs exposed between components)

The resulting user-facing code is significantly shorter and more readable, with the numerical integration details fully encapsulated.