### PR TITLE
Buggy copy in watchdog

### DIFF
--- a/amigo/optimizer/optimizer.py
+++ b/amigo/optimizer/optimizer.py
@@ -3328,7 +3328,6 @@ class Optimizer:
                                 ] = watchdog_iterate
                                 self.vars.get_solution().copy_host_to_device()
                                 self.update.copy(watchdog_update_backup)
-                                self.update.copy_host_to_device()
                                 self.px.get_array()[:] = watchdog_px
                                 self.px.copy_host_to_device()
                                 self._update_gradient(self.vars.get_solution())


### PR DESCRIPTION
I'm getting an error when the watchdog triggers as shown below. This gets rid of the error. I don't think OptVector is meant to have a `.copy_host_to_device()`?

```
  Watchdog trial 3/3 (force accept)
  44   6.40e+03  -6.85222e+07   3.99e+00   9.24e+10   5.95e+06   3.14e+04   2.47e+12       ---  6.13e-02  3.87e-01   1     0
Traceback (most recent call last):
  File "~/git/amigo/amigo/optimizer/optimizer.py", line 3331, in optimize
    self.update.copy_host_to_device()
AttributeError: 'amigo.amigo.OptVector' object has no attribute 'copy_host_to_device'
```