### PR TITLE
Passing pytest and working solver fixes

### DIFF
--- a/amigo/optimizer/solvers/amigo_solver.py
+++ b/amigo/optimizer/solvers/amigo_solver.py
@@ -4,7 +4,7 @@ from amigo import MemoryLocation, SolverType, SparseLDL
 
 class AmigoSolver(LinearSolver):
     """Use the native Amigo LDL solver"""
-    
+
     supports_inertia = True
 
     def __init__(self, problem, ustab=0.01, pivot_tol=1e-14):

--- a/amigo/optimizer/solvers/amigo_solver.py
+++ b/amigo/optimizer/solvers/amigo_solver.py
@@ -4,11 +4,17 @@ from amigo import MemoryLocation, SolverType, SparseLDL
 
 class AmigoSolver(LinearSolver):
     """Use the native Amigo LDL solver"""
+    
+    supports_inertia = True
 
     def __init__(self, problem, ustab=0.01, pivot_tol=1e-14):
         self.problem = problem
         loc = MemoryLocation.HOST_AND_DEVICE
         self.hess = self.problem.create_matrix(loc)
+        self.nrows, self.ncols, self.nnz, self.rowp, self.cols = (
+            self.hess.get_nonzero_structure()
+        )
+        self._diag_indices = self._find_diag_indices(self.rowp, self.cols, self.nrows)
 
         # Create the sparse LDL solver
         stype = SolverType.LDL

--- a/amigo/optimizer/solvers/linear_solver.py
+++ b/amigo/optimizer/solvers/linear_solver.py
@@ -11,7 +11,7 @@ class LinearSolver(ABC):
     get_inertia().
     """
 
-    @abstractmethod
+    # @abstractmethod
     def eval_hessian(self, alpha, x):
         """
         Evaluate and save the Hessian at the given design point.

--- a/amigo/optimizer/solvers/scipy_solver.py
+++ b/amigo/optimizer/solvers/scipy_solver.py
@@ -5,6 +5,9 @@ from scipy.sparse.linalg import splu
 
 
 class DirectScipySolver(LinearSolver):
+    
+    supports_inertia = False
+    
     def __init__(self, problem):
         self.problem = problem
         loc = MemoryLocation.HOST_AND_DEVICE

--- a/amigo/optimizer/solvers/scipy_solver.py
+++ b/amigo/optimizer/solvers/scipy_solver.py
@@ -5,9 +5,9 @@ from scipy.sparse.linalg import splu
 
 
 class DirectScipySolver(LinearSolver):
-    
+
     supports_inertia = False
-    
+
     def __init__(self, problem):
         self.problem = problem
         loc = MemoryLocation.HOST_AND_DEVICE

--- a/tests/interp/test_smt_quadratic.py
+++ b/tests/interp/test_smt_quadratic.py
@@ -14,7 +14,7 @@ Run with:
 """
 
 import numpy as np
-import pytest
+import pytest, os
 
 import amigo as am
 from amigo.interp import ExternalSMTComponent
@@ -35,9 +35,10 @@ def trained_krg():
     return sm
 
 
-@pytest.fixture(scope="module")
-def opt_result(trained_krg):
+@pytest.fixture(scope="module", params=["mumps", "amigo"])
+def opt_result(request, trained_krg):
     """Build and solve the model once; return (xvec, model)."""
+    solver = request.param
     sm = trained_krg
     smt_ext = ExternalSMTComponent(num_points=1, num_inputs=1, smt_model=sm)
 
@@ -87,7 +88,7 @@ def opt_result(trained_krg):
     lower["src.y"] = 0.25
     upper["src.y"] = float("inf")
 
-    opt = am.Optimizer(model, xvec, lower=lower, upper=upper, solver="mumps")
+    opt = am.Optimizer(model, xvec, lower=lower, upper=upper, solver=solver)
     data = opt.optimize(
         {
             "max_iterations": 200,


### PR DESCRIPTION
## Summary
Fixes the `LinearSolver` abstract base class interface to run in its current state. Extends pytest to run against both `"mumps"` and `"amigo"` solvers.

### Changes
- **`linear_solver.py`**: Temporarily un-marks `eval_hessian` as `@abstractmethod` to allow subclasses that override the Hessian evaluation differently (or don't implement Hessian evaluation) without triggering ABC errors.
- **`amigo_solver.py`**: Adds `supports_inertia = True` class attribute and pre-computes the sparse matrix nonzero structure (`rowp`, `cols`, etc.) along with diagonal indices (`_diag_indices`) at construction time. This is required for inertia computation in the LDL factorization workflow.
- **`scipy_solver.py`**: Adds `supports_inertia = False` class attribute to `DirectScipySolver`, making capability discovery consistent across all solver implementations.
- **`tests/interp/test_smt_quadratic.py`**: Parametrizes the `opt_result` fixture to run against both `"mumps"` and `"amigo"` solvers, improving solver coverage in the integration test suite.