### PR TITLE
Amigo solver improvements

### DIFF
--- a/amigo/algorithm/solvers/amigo_solver.py
+++ b/amigo/algorithm/solvers/amigo_solver.py
@@ -7,7 +7,7 @@ which lets it drive Algorithm IC inertia correction.
 import numpy as np
 
 from . import DirectSparseSolver
-from amigo import SolverType, SparseLDL
+from amigo import SolverType, SparseLDL, OrderingType
 
 
 class AmigoSolver(DirectSparseSolver):
@@ -19,7 +19,11 @@ class AmigoSolver(DirectSparseSolver):
     def __init__(self, problem, ustab=0.01, pivot_tol=1e-14):
         self._init_sparse_structure(problem)
         self.ldl = SparseLDL(
-            self.hess, SolverType.LDL, ustab=ustab, pivot_tol=pivot_tol
+            self.hess,
+            SolverType.LDL,
+            ustab=ustab,
+            pivot_tol=pivot_tol,
+            order=OrderingType.DEFAULT,
         )
 
     def _do_factor(self):

--- a/amigo/amigo.cpp
+++ b/amigo/amigo.cpp
@@ -160,11 +160,19 @@ void bind_vector(py::module_& m, const std::string& name) {
 
 py::array_t<int> reorder_model(amigo::OrderingType order_type,
                                std::vector<py::array_t<int>> arrays,
-                               py::object output_vars = py::none()) {
+                               py::array_t<int> num_cons = py::none(),
+                               py::object con_indices = py::none()) {
   std::vector<int> intervals(arrays.size() + 1);
   intervals[0] = 0;
 
   int max_node = 0;
+
+  if (!num_cons.is_none()) {
+    if (arrays.size() != num_cons.size()) {
+      throw std::runtime_error(
+          "The constraints and input arrays must be the same size");
+    }
+  }
 
   // Check the dimension of the arrays
   ssize_t max_columns = 0;
@@ -195,9 +203,11 @@ py::array_t<int> reorder_model(amigo::OrderingType order_type,
   int nrows = max_node, ncols = max_node;
   int nelems = intervals[arrays.size()];
 
+  auto nc = num_cons.unchecked<1>();
   std::vector<int> columns(max_columns);
 
-  auto element_nodes = [&](int element, const int** ptr) {
+  auto element_nodes = [&](int element, const int** ptr, int* ncon = nullptr,
+                           bool* is_linear = nullptr) {
     // upper_bound finds the first index i such that intervals[i] >
     // element
     auto it = std::upper_bound(intervals.begin(), intervals.end(), element);
@@ -212,6 +222,16 @@ py::array_t<int> reorder_model(amigo::OrderingType order_type,
     int ncols = r.shape(1);
     for (int j = 0; j < ncols; j++) {
       columns[j] = r(elem, j);
+    }
+
+    if (ncon) {
+      *ncon = 0;
+      if (!num_cons.is_none()) {
+        *ncon = nc(idx);
+      }
+    }
+    if (is_linear) {
+      *is_linear = false;
     }
 
     *ptr = columns.data();
@@ -229,20 +249,20 @@ py::array_t<int> reorder_model(amigo::OrderingType order_type,
 
   // Compute the reordering
   int *perm, *iperm;
-  if (!output_vars.is_none()) {
-    auto output_array = output_vars.cast<py::array_t<int>>();
-    auto outputs_ = output_array.unchecked<1>();
+  if (!con_indices.is_none()) {
+    auto con_array = con_indices.cast<py::array_t<int>>();
+    auto cons_ = con_array.unchecked<1>();
 
-    int num_outputs = outputs_.shape(0);
-    int* outputs = new int[num_outputs];
-    for (int i = 0; i < num_outputs; i++) {
-      outputs[i] = outputs_[i];
+    int num_constraints = cons_.shape(0);
+    int* cons = new int[num_constraints];
+    for (int i = 0; i < num_constraints; i++) {
+      cons[i] = cons_[i];
     }
 
     amigo::OrderingUtils::reorder_block(order_type, nrows, rowp, cols,
-                                        num_outputs, outputs, &perm, &iperm);
+                                        num_constraints, cons, &perm, &iperm);
 
-    delete[] outputs;
+    delete[] cons;
   } else {
     amigo::OrderingUtils::reorder(order_type, nrows, rowp, cols, &perm, &iperm);
   }
@@ -296,7 +316,8 @@ PYBIND11_MODULE(amigo, mod) {
       .export_values();
 
   mod.def("reorder_model", &reorder_model, py::arg("order_type"),
-          py::arg("arrays"), py::arg("output_indices") = py::none());
+          py::arg("arrays"), py::arg("num_cons") = py::none(),
+          py::arg("output_indices") = py::none());
 
   py::class_<amigo::CSRMat<double>, std::shared_ptr<amigo::CSRMat<double>>>(
       mod, "CSRMat")

--- a/amigo/component.py
+++ b/amigo/component.py
@@ -352,11 +352,16 @@ class ConstraintSet:
         self.multipliers = {}
         self.meta = {}
         self.arg_index = 0
+        self.ncon = 0
 
     def add(self, name, shape=None, type=float, **kwargs):
         # Add the constraint
         self.cons[name] = self.ConstrExpr(name, shape=shape, type=type)
         self.meta[name] = Meta(name, "constraint", shape=shape, type=type, **kwargs)
+        if shape is None:
+            self.ncon += 1
+        else:
+            self.ncon += np.prod(shape)
 
         # Add the associated multiplier
         multiplier_name = self._get_multiplier_name(name)
@@ -405,6 +410,9 @@ class ConstraintSet:
         else:
             raise KeyError(f"{name} not in declared constraints")
 
+    def get_num_constraints(self):
+        return self.ncon
+
     def generate_cpp_types(self, template_name="T__"):
         shapes = [self.cons[name].shape for name in self.cons]
         return _generate_cpp_types(shapes, template_name=template_name)
@@ -425,6 +433,10 @@ class ConstraintSet:
             d = data[name]
             obj.meta[name] = Meta.deserialize(d["meta"])
             obj.cons[name] = cls.ConstrExpr.deserialize(d["expr"])
+            if obj.cons[name].shape is None:
+                self.ncon += 1
+            else:
+                obj.ncon += np.prod(obj.cons[name].shape)
         return obj
 
 
@@ -811,6 +823,9 @@ class Component:
             out_shapes[name] = shape
         return out_shapes
 
+    def get_num_constraints(self):
+        return self.constraints.get_num_constraints()
+
     def _is_overridden(self, method_name):
         instance_method = getattr(type(self), method_name, None)
         base_method = getattr(Component, method_name, None)
@@ -930,6 +945,8 @@ class Component:
             cpp += (
                 "  " + f"static constexpr int ncomp = Input<{template_name}>::ncomp;\n"
             )
+            ncon = self.constraints.get_num_constraints()
+            cpp += "  " + f"static constexpr int nconstraints = {ncon};\n"
         else:
             cpp += (
                 "  "
@@ -937,6 +954,10 @@ class Component:
                 + f"typename A2D::VarTuple<{using_template}, {using_template}>;\n"
             )
             cpp += "  " + "static constexpr int ncomp = 0;\n"
+            cpp += "  " + "static constexpr int nconstraints = 0;\n"
+
+        # For now nothing is linear
+        cpp += "  " + "static constexpr bool is_linear = false;\n"
 
         # Add the data statement
         if len(self.data) > 0:

--- a/amigo/model.py
+++ b/amigo/model.py
@@ -775,16 +775,20 @@ class Model:
 
     def _reorder_indices(self, order_type, order_for_block=False):
         arrays = []
+        num_cons = []
         for name, comp in self.comp.items():
             array = comp.get_indices(comp.vars)
             if array.size > 0:
                 arrays.append(array)
+                ncon = comp.comp_obj.get_num_constraints()
+                num_cons.append(ncon)
 
+        num_cons = np.array(num_cons, dtype=int)
         if order_for_block:
             constraint_indices = self._get_constraint_indices()
-            iperm = reorder_model(order_type, arrays, constraint_indices)
+            iperm = reorder_model(order_type, arrays, num_cons, constraint_indices)
         else:
-            iperm = reorder_model(order_type, arrays)
+            iperm = reorder_model(order_type, arrays, num_cons)
 
         # Apply the reordering to the variables
         for name, comp in self.comp.items():

--- a/include/component_group.h
+++ b/include/component_group.h
@@ -643,10 +643,13 @@ class ComponentGroup : public ComponentGroupBase<T, policy> {
 
   static constexpr int ncomp = __get_collection_ncomp<Components...>::value;
   static constexpr int ndata = __get_collection_ndata<Components...>::value;
+  static constexpr int nconstraints =
+      __get_collection_nconstraints<Components...>::value;
   static constexpr int noutputs =
       __get_collection_noutputs<Components...>::value;
   static constexpr bool continuation =
       __get_collection_continuation<Components...>::value;
+  static constexpr bool linear = __get_collection_linear<Components...>::value;
 
   // Use whatever class is defined as the default backend
   using Backend =
@@ -673,6 +676,8 @@ class ComponentGroup : public ComponentGroupBase<T, policy> {
   }
 
   bool is_continuation() const { return continuation; }
+  bool is_linear() const { return linear; }
+  int get_num_component_constraints() const { return nconstraints; }
 
   // Group compute functions
   T lagrangian(T alpha, const Vector<T>& data_vec, const Vector<T>& vec) const {

--- a/include/component_group_base.h
+++ b/include/component_group_base.h
@@ -23,6 +23,14 @@ class ComponentGroupBase {
   // Define whether this is a component intended for continuation or not
   virtual bool is_continuation() const { return false; }
 
+  // Does this component define a linear objective function and linear
+  // constraints
+  virtual bool is_linear() const { return false; }
+
+  // How many constraints does this component define
+  virtual int get_num_component_constraints() const { return 0; }
+
+  // Evaluate the Lagrangian
   virtual T lagrangian(T alpha, const Vector<T>& data,
                        const Vector<T>& x) const {
     return T(0.0);
@@ -210,6 +218,19 @@ struct __get_collection_noutputs<T, Ts...> {
 };
 
 template <class... Ts>
+struct __get_collection_nconstraints;
+
+template <class T>
+struct __get_collection_nconstraints<T> {
+  static constexpr int value = T::nconstraints;
+};
+
+template <class T, class... Ts>
+struct __get_collection_nconstraints<T, Ts...> {
+  static constexpr int value = __get_collection_nconstraints<Ts...>::value;
+};
+
+template <class... Ts>
 struct __get_collection_continuation;
 
 template <class T>
@@ -220,6 +241,19 @@ struct __get_collection_continuation<T> {
 template <class T, class... Ts>
 struct __get_collection_continuation<T, Ts...> {
   static constexpr int value = __get_collection_continuation<Ts...>::value;
+};
+
+template <class... Ts>
+struct __get_collection_linear;
+
+template <class T>
+struct __get_collection_linear<T> {
+  static constexpr int value = T::is_linear;
+};
+
+template <class T, class... Ts>
+struct __get_collection_linear<T, Ts...> {
+  static constexpr int value = __get_collection_linear<Ts...>::value;
 };
 
 }  // namespace amigo

--- a/include/optimization_problem.h
+++ b/include/optimization_problem.h
@@ -1111,7 +1111,8 @@ class OptimizationProblem {
       intervals[i + 1] = intervals[i] + num_elems;
     }
 
-    auto element_nodes = [&](int element, const int** ptr) {
+    auto element_nodes = [&](int element, const int** ptr, int* ncon = nullptr,
+                             bool* linear = nullptr) {
       // upper_bound finds the first index i such that intervals[i] >
       // element
       auto it = std::upper_bound(intervals.begin(), intervals.end(), element);
@@ -1129,6 +1130,12 @@ class OptimizationProblem {
         *ptr = &data[nnodes_per_elem * elem];
       } else {
         *ptr = nullptr;
+      }
+      if (ncon) {
+        *ncon = components[idx]->get_num_component_constraints();
+      }
+      if (linear) {
+        *linear = components[idx]->is_linear();
       }
       return nnodes_per_elem;
     };
@@ -1153,7 +1160,8 @@ class OptimizationProblem {
       intervals[i + 1] = intervals[i] + num_elems;
     }
 
-    auto element_nodes = [&](int element, const int** ptr) {
+    auto element_nodes = [&](int element, const int** ptr, int* ncon = nullptr,
+                             bool* linear = nullptr) {
       // upper_bound finds the first index i such that intervals[i] >
       // element
       auto it = std::upper_bound(intervals.begin(), intervals.end(), element);
@@ -1171,6 +1179,12 @@ class OptimizationProblem {
         *ptr = &data[ndata_per_elem * elem];
       } else {
         *ptr = nullptr;
+      }
+      if (ncon) {
+        *ncon = 0;
+      }
+      if (linear) {
+        *linear = false;
       }
       return ndata_per_elem;
     };

--- a/include/ordering_utils.h
+++ b/include/ordering_utils.h
@@ -406,12 +406,42 @@ class OrderingUtils {
         int elem = node_to_elem[j];
 
         const int* ptr;
-        int nodes_per_element = element_nodes(elem, &ptr);
-        for (int k = 0; k < nodes_per_element; k++, ptr++) {
-          int node = ptr[0];
-          if (counter[node] < i) {
-            counter[node] = i;
-            nnz_count++;
+        int ncon = 0;
+        bool is_linear = false;
+        int nodes_per_element = element_nodes(elem, &ptr, &ncon, &is_linear);
+        if (is_linear || ncon > 0) {
+          // Find the i-index of the row
+          int ii = 0;
+          for (; ii < nodes_per_element; ii++) {
+            if (i == ptr[ii]) {
+              break;
+            }
+          }
+
+          // Set the start/end of the array
+          int kstart = 0;
+          int kend = nodes_per_element;
+          if (ii >= nodes_per_element - ncon) {
+            kend = nodes_per_element - ncon;
+          } else if (is_linear) {
+            kstart = nodes_per_element - ncon;
+          }
+
+          // Check if we should add this node
+          for (int k = kstart; k < kend; k++) {
+            int node = ptr[k];
+            if (counter[node] < i) {
+              counter[node] = i;
+              nnz_count++;
+            }
+          }
+        } else {
+          for (int k = 0; k < nodes_per_element; k++) {
+            int node = ptr[k];
+            if (counter[node] < i) {
+              counter[node] = i;
+              nnz_count++;
+            }
           }
         }
       }
@@ -441,13 +471,44 @@ class OrderingUtils {
         int elem = node_to_elem[j];
 
         const int* ptr;
-        int nodes_per_element = element_nodes(elem, &ptr);
-        for (int k = 0; k < nodes_per_element; k++, ptr++) {
-          int node = ptr[0];
-          if (counter[node] < i) {
-            counter[node] = i;
-            cols[nnz_count] = node;
-            nnz_count++;
+        int ncon = 0;
+        bool is_linear = false;
+        int nodes_per_element = element_nodes(elem, &ptr, &ncon, &is_linear);
+        if (is_linear || ncon > 0) {
+          // Find the i-index of the row
+          int ii = 0;
+          for (; ii < nodes_per_element; ii++) {
+            if (i == ptr[ii]) {
+              break;
+            }
+          }
+
+          // Set the start/end of the array
+          int kstart = 0;
+          int kend = nodes_per_element;
+          if (ii >= nodes_per_element - ncon) {
+            kend = nodes_per_element - ncon;
+          } else if (is_linear) {
+            kstart = nodes_per_element - ncon;
+          }
+
+          // Check if we should add this node
+          for (int k = kstart; k < kend; k++) {
+            int node = ptr[k];
+            if (counter[node] < i) {
+              counter[node] = i;
+              cols[nnz_count] = node;
+              nnz_count++;
+            }
+          }
+        } else {
+          for (int k = 0; k < nodes_per_element; k++) {
+            int node = ptr[k];
+            if (counter[node] < i) {
+              counter[node] = i;
+              cols[nnz_count] = node;
+              nnz_count++;
+            }
           }
         }
       }

--- a/include/sparse_ldl.h
+++ b/include/sparse_ldl.h
@@ -2772,11 +2772,13 @@ class SparseLDL {
                         int* new_node_ptr_[], int* new_node_to_vars_[],
                         int* new_vars_to_node_[], int* new_colcounts_[],
                         int* new_node_parent_[], int work[],
-                        const int max_node_width = 32,
-                        const int max_zeros_added = 64) {
+                        const int max_node_width = 64,
+                        const int max_zeros_added = 256) {
     int* root_of = work;
     int* root_colcount = &work[num_snodes];
     int* width = &work[2 * num_snodes];
+    int* new_non_zeros = &work[3 * num_snodes];
+    std::fill(new_non_zeros, new_non_zeros + num_snodes, 0);
 
     // Initialize the supernode data
     for (int is = 0; is < num_snodes; is++) {
@@ -2806,8 +2808,20 @@ class SparseLDL {
       int start = snode_children_ptr[is];
       int end = snode_children_ptr[is + 1];
 
+      std::vector<int> kids(end - start);
+      for (int ip = start, i = 0; ip < end; ip++, i++) {
+        int child = snode_children[ip];
+        kids[i] = ip;
+      }
+
+      std::sort(kids.begin(), kids.end(), [&](int a, int b) {
+        return width[find_root(a)] < width[find_root(b)];
+      });
+
       // Loop over the children
-      for (int ip = start; ip < end; ip++) {
+      for (int i = 0; i < kids.size(); i++) {
+        int ip = kids[i];
+
         // For each child, check if we can merge
         int child = snode_children[ip];
 
@@ -2827,11 +2841,13 @@ class SparseLDL {
           int zeros_added = extra_rows * width[r_child];
 
           // Okay, merge the supernodes
-          if (zeros_added <= max_zeros_added) {
+          if (new_non_zeros[r_parent] + new_non_zeros[r_child] + zeros_added <=
+              max_zeros_added) {
             root_colcount[r_parent] =
                 merged_width + root_colcount[r_parent] - width[r_parent];
             width[r_parent] = merged_width;
             root_of[r_child] = r_parent;
+            new_non_zeros[r_parent] += zeros_added + new_non_zeros[r_child];
           }
         }
       }

--- a/src/csr_matrix_backend.cu
+++ b/src/csr_matrix_backend.cu
@@ -33,7 +33,7 @@ void add_diagonal_cuda(int nrows, const int* d_indices, const T* d_values,
 
 template <typename T>
 AMIGO_KERNEL void zero_at_indices(int nentries, const int* d_indices,
-                                  double* d_array) {
+                                  T* d_array) {
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < nentries;
        i += blockDim.x * gridDim.x) {
     d_array[d_indices[i]] = 0.0;
@@ -45,7 +45,7 @@ void zero_at_indices_cuda(int nentries, const int* d_indices, T* d_array,
                           cudaStream_t stream) {
   constexpr int TPB = 256;
 
-  int grid = (nrows + TPB - 1) / TPB;
+  int grid = (nentries + TPB - 1) / TPB;
   zero_at_indices<T><<<grid, TPB, 0, stream>>>(nentries, d_indices, d_array);
 }
 
@@ -64,7 +64,7 @@ void set_value_at_indices_cuda(const T value, int nentries,
                                cudaStream_t stream) {
   constexpr int TPB = 256;
 
-  int grid = (nrows + TPB - 1) / TPB;
+  int grid = (nentries + TPB - 1) / TPB;
   set_value_at_indices<T>
       <<<grid, TPB, 0, stream>>>(value, nentries, d_indices, d_array);
 }

--- a/src/optimizer_backend.cu
+++ b/src/optimizer_backend.cu
@@ -5,7 +5,7 @@
 
 #include "a2dcore.h"
 #include "amigo.h"
-#include "optimizer_backend.h"
+#include "interior_point_backend.h"
 
 namespace amigo {
 


### PR DESCRIPTION
- Removed zeros from the non-zero pattern
- Modified the AmigoSolver class to reorder using the default ordering scheme (this is required since the slack variables modify the non-zero pattern after initialization)
- Added is_linear flag to the c++ component class, but still need to set that from examining the python expressions